### PR TITLE
Fix rockspec git URL so luarocks install works

### DIFF
--- a/torch_binding/rocks/warp-ctc-scm-1.rockspec
+++ b/torch_binding/rocks/warp-ctc-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "warp-ctc"
 version = "scm-1"
 
 source = {
-   url = "https://github.com/baidu-research/warp-ctc",
+   url = "git://github.com/baidu-research/warp-ctc.git",
 }
 
 description = {


### PR DESCRIPTION
Standard way to install rocks is `luarocks install http://raw.githubusercontent.com/<rockspec URL>`, but luarocks won't treat the URL as a git repository if it begins with http. This PR fixes the git repo URL for `install` to work.
