### PR TITLE
`make install` will now install libwarpctc to standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,9 @@ IF (CUDA_FOUND)
     TARGET_LINK_LIBRARIES(test_gpu warpctc ${CUDA_curand_LIBRARY})
 
     INSTALL(TARGETS warpctc
-            RUNTIME DESTINATION "${CMAKE_BINARY_DIR}"
-            LIBRARY DESTINATION "${CMAKE_BINARY_DIR}"
-            ARCHIVE DESTINATION "${CMAKE_BINARY_DIR}")
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib/static)
 
     IF (Torch_FOUND)
         MESSAGE(STATUS "Building Torch Bindings with GPU support")
@@ -112,9 +112,9 @@ ELSE()
     SET_TARGET_PROPERTIES(test_cpu PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 
     INSTALL(TARGETS warpctc
-            RUNTIME DESTINATION "${CMAKE_BINARY_DIR}"
-            LIBRARY DESTINATION "${CMAKE_BINARY_DIR}"
-            ARCHIVE DESTINATION "${CMAKE_BINARY_DIR}")
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib/static)
 
     IF (Torch_FOUND)
         MESSAGE(STATUS "Building Torch Bindings with no GPU support")


### PR DESCRIPTION
Currently, there is no good way to install the dynamic library to a standard location. This PR will now allow user to `make install` which puts libwarpctc in `/usr/local/lib`.

This is needed for the Python bindings I'm working on, and seems like a good idea, to let the user install the library in a standard location rather than keeping it in the build directory.