### PR TITLE
Add a TensorFlow kernel that wraps WarpCTC

### DIFF
--- a/include/ctc.h
+++ b/include/ctc.h
@@ -33,8 +33,10 @@ typedef enum {
 } ctcComputeLocation;
 
 /** Structure used for options to the CTC compution.  Applications
- *  should zero out the array using sizeof(struct ctcOptions) to
- *  ensure forward compatibility with added options. */
+ *  should zero out the array using memset and sizeof(struct
+ *  ctcOptions) in C or default initialization (e.g. 'ctcOptions
+ *  options{};' or 'auto options = ctcOptions{}') in C++ to ensure
+ *  forward compatibility with added options. */
 struct ctcOptions {
     /// indicates where the ctc calculation should take place {CTC_CPU | CTC_GPU}
     ctcComputeLocation loc;

--- a/include/detail/ctc_helper.h
+++ b/include/detail/ctc_helper.h
@@ -8,7 +8,6 @@
 
 namespace ctc_helper {
 
-static const int BLANK = 0;
 static const float threshold = 1e-1;
 
 template<typename T>

--- a/include/detail/gpu_ctc_kernels.h
+++ b/include/detail/gpu_ctc_kernels.h
@@ -112,7 +112,7 @@ void compute_alpha_kernel (const ProbT* probs, const int *label_sizes,
     {
         const int label_start_offset = label_offsets[blockIdx.x];
         for (int idx = tid; idx < L; idx += blockDim.x) {
-            int offset = (blockIdx.x * S_memoffset) + 2 * idx;
+            const int offset = (blockIdx.x * S_memoffset) + 2 * idx;
             labels_with_blanks[offset] = blank_label;
             labels_with_blanks[offset+1] = labels_without_blanks[label_start_offset + idx];
         }

--- a/src/ctc_entrypoint.cpp
+++ b/src/ctc_entrypoint.cpp
@@ -13,7 +13,7 @@
 extern "C" {
 
 int get_warpctc_version() {
-    return 1;
+    return 2;
 }
 
 const char* ctcGetStatusString(ctcStatus_t status) {

--- a/tensorflow_binding/.gitignore
+++ b/tensorflow_binding/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+dist
+*.egg-info
+*.so
+include/cuda

--- a/tensorflow_binding/.gitignore
+++ b/tensorflow_binding/.gitignore
@@ -3,3 +3,4 @@ dist
 *.egg-info
 *.so
 include/cuda
+*.pyc

--- a/tensorflow_binding/README.md
+++ b/tensorflow_binding/README.md
@@ -39,9 +39,9 @@ make
 ```
 
 Otherwise, set `WARP_CTC_PATH` to wherever you have `libwarpctc.so`
-installed. You should also make sure that `CUDA_HOME` is set to the
-home cuda directory (i.e. where `include/cuda.h` and `lib/libcudart.so`
-live).
+installed. If you have a GPU, you should also make sure that
+`CUDA_HOME` is set to the home cuda directory (i.e. where
+`include/cuda.h` and `lib/libcudart.so` live).
 
 You should now be able to use `setup.py` to install the package into
 your current Python environment:

--- a/tensorflow_binding/README.md
+++ b/tensorflow_binding/README.md
@@ -1,0 +1,93 @@
+
+# TensorFlow binding for WarpCTC
+
+This package provides TensorFlow kernels that wrap the WarpCTC
+library.  Kernels are provided for both the CTCLoss op already in
+TensorFlow, as well as a new WarpCTC op provided in this package.  The
+WarpCTC op has an interface that more closely matches the native
+WarpCTC interface than TensorFlow's CTCLoss op. Note that the CTCLoss
+op expects the reserved blank label to be the largest value while the
+WarpCTC op expects the reserved blank label to be label `0`.
+
+## Installation
+
+To build the kernels it is necessary to have the TensorFlow source
+code available, since TensorFlow doesn't currently install the
+necessary headers to handle the SparseTensor that the CTCLoss op uses
+to input the labels.  You can retrieve the TensorFlow source from
+github.com:
+
+```bash
+git clone https://github.com/tensorflow/tensorflow.git
+```
+
+Tell the build scripts where you have the TensorFlow source tree by
+setting the `TENSORFLOW_SRC_PATH` environment variable:
+
+```bash
+export TENSORFLOW_SRC_PATH=/path/to/tensorflow
+```
+
+`WARP_CTC_PATH` should be set to the location of a built WarpCTC
+(i.e. `libwarpctc.so`).  This defaults to `../build`, so from within a
+new warp-ctc clone you could build WarpCTC like this:
+
+```bash
+mkdir build; cd build
+cmake ..
+make
+```
+
+Otherwise, set `WARP_CTC_PATH` to wherever you have `libwarpctc.so`
+installed. You should also make sure that `CUDA_HOME` is set to the
+home cuda directory (i.e. where `include/cuda.h` and `lib/libcudart.so`
+live).
+
+You should now be able to use `setup.py` to install the package into
+your current Python environment:
+
+```bash
+python setup.py install
+```
+
+You can run a few unit tests with `setup.py` as well if you want:
+
+```bash
+python setup.py test
+```
+
+## Using the kernels
+
+First import the module:
+
+```python
+import warpctc_tensorflow
+```
+
+The GPU kernel for the existing `CTCLoss` op is registered and ready
+to use.  If you want to use WarpCTC as the CPU kernel for the
+`CTCLoss` op you can use the ("experimental") `_kernel_label_map`
+function to tell TensorFlow to use WarpCTC kernels instead of the
+default CPU kernel:
+
+```python
+with tf.get_default_graph()._kernel_label_map({"CTCLoss": "WarpCTC"}):
+    ...
+    loss = tf.nn.ctc_loss(inputs, labels, seq_lens)
+```
+
+Note that `proprocess_collapse_repeated` must be `False` and
+`ctc_merge_repeated` must be `True` (their default values) as these
+options are not currently supported.
+
+The WarpCTC op is available via the `warpctc_tensorflow.ctc` function:
+
+```python
+costs = warpctc_tensorflow.ctc(activations, input_lengths, flat_labels, label_lengths)
+```
+
+The `activations` input is a 3 dimensional Tensor and all the others
+are single dimension Tensors.  See the main WarpCTC documentation for
+more information.
+    
+    

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -1,8 +1,10 @@
 """setup.py script for warp-ctc TensorFlow wrapper"""
 
 import os
+import re
 import setuptools
 import sys
+import unittest
 from setuptools.command.build_ext import build_ext as orig_build_ext
 
 # We need to import tensorflow to find where its include directory is.
@@ -81,16 +83,23 @@ class build_tf_ext(orig_build_ext):
         self.compiler.compiler_so.remove('-Wstrict-prototypes')
         orig_build_ext.build_extensions(self)
 
-import unittest
 def discover_test_suite():
     test_loader = unittest.TestLoader()
     test_suite = test_loader.discover('tests', pattern='test_*.py')
     return test_suite
 
+# Read the README.md file for the long description. This lets us avoid
+# duplicating the package description in multiple places in the source.
+README_PATH = os.path.join(os.path.dirname(__file__), "README.md")
+with open(README_PATH, "r") as handle:
+    # Extract everything between the first set of ## headlines
+    LONG_DESCRIPTION = re.search("#.*([^#]*)##", handle.read()).group(1).strip()
+
 setuptools.setup(
     name = "warpctc_tensorflow",
     version = "0.1",
     description = "TensorFlow wrapper for warp-ctc",
+    long_description = LONG_DESCRIPTION,
     url = "https://github.com/baidu-research/warp-ctc",
     author = "Jared Casper",
     author_email = "jared.casper@baidu.com",

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -76,7 +76,7 @@ ext = setuptools.Extension('warpctc_tensorflow.kernels',
                            language = 'c++',
                            include_dirs = include_dirs,
                            library_dirs = [warp_ctc_path],
-                           runtime_library_dirs = [warp_ctc_path],
+                           runtime_library_dirs = [os.path.realpath(warp_ctc_path)],
                            libraries = ['warpctc'],
                            extra_compile_args = extra_compile_args)
 

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -33,7 +33,7 @@ if "WARP_CTC_PATH" in os.environ:
 if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc.so")):
     print(("Could not find libwarpctc.so in {}.\n"
            "Build warp-ctc and set WARP_CTC_PATH to the location of"
-           " labwarpctc.so (default is '../build')").format(warp_ctc_path),
+           " libwarpctc.so (default is '../build')").format(warp_ctc_path),
           file=sys.stderr)
     sys.exit(1)
 

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -65,8 +65,10 @@ extra_compile_args = ['-std=c++11', '-fPIC']
 # current tensorflow code triggers return type errors, silence those for now
 extra_compile_args += ['-Wno-return-type']
 
+lib_srcs = ['src/ctc_op_kernel.cc', 'src/warpctc_op.cc']
+
 ext = setuptools.Extension('warpctc_tensorflow.kernels',
-                           sources = ['src/ctc_op_kernel.cc'],
+                           sources = lib_srcs,
                            language = 'c++',
                            include_dirs = include_dirs,
                            library_dirs = [warp_ctc_path],

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -1,0 +1,100 @@
+"""setup.py script for warp-ctc TensorFlow wrapper"""
+
+import os
+import setuptools
+import sys
+from setuptools.command.build_ext import build_ext as orig_build_ext
+
+# We need to import tensorflow to find where its include directory is.
+try:
+    import tensorflow as tf
+except ImportError:
+    raise RuntimeError("Tensorflow must be installed to build the tensorflow wrapper.")
+
+if "CUDA_HOME" not in os.environ:
+    print("Please define the CUDA_HOME environment variable.\n"
+          "This should be a path which contains include/cuda.h",
+          file=sys.stderr)
+    sys.exit(1)
+
+if "TENSORFLOW_SRC_PATH" not in os.environ:
+    print("Please define the TENSORFLOW_SRC_PATH environment variable.\n"
+          "This should be a path to the Tensorflow source directory.",
+          file=sys.stderr)
+    sys.exit(1)
+
+warp_ctc_path = "../build"
+if "WARP_CTC_PATH" in os.environ:
+    warp_ctc_path = os.environ["WARP_CTC_PATH"]
+if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc.so")):
+    print(("Could not find libwarpctc.so in {}.\n"
+           "Build warp-ctc and set WARP_CTC_PATH to the location of"
+           " labwarpctc.so (default is '../build')").format(warp_ctc_path),
+          file=sys.stderr)
+    sys.exit(1)
+
+root_path = os.path.realpath(os.path.dirname(__file__))
+
+tf_include = tf.sysconfig.get_include()
+tf_src_dir = os.environ["TENSORFLOW_SRC_PATH"]
+tf_includes = [tf_include, tf_src_dir]
+warp_ctc_includes = [os.path.join(root_path, '../include'),
+                     os.path.join(root_path, 'include')]
+cuda_includes = [os.path.join(os.environ["CUDA_HOME"], 'include')]
+include_dirs = tf_includes + warp_ctc_includes + cuda_includes
+
+# mimic tensorflow cuda include setup so that their include command work
+if not os.path.exists(os.path.join(root_path, "include")):
+    os.mkdir(os.path.join(root_path, "include"))
+
+cuda_inc_path = os.path.join(root_path, "include/cuda")
+if not os.path.exists(cuda_inc_path) or os.readlink(cuda_inc_path) != os.environ["CUDA_HOME"]:
+    if os.path.exists(cuda_inc_path):
+        os.remove(cuda_inc_path)
+    os.symlink(os.environ["CUDA_HOME"], cuda_inc_path)
+
+# Ensure that all expected files and directories exist.
+for loc in include_dirs:
+    if not os.path.exists(loc):
+        print(("Could not find file or directory {}.\n"
+               "Check your environment variables and paths?").format(loc),
+              file=sys.stderr)
+        sys.exit(1)
+
+extra_compile_args = ['-std=c++11', '-fPIC']
+# current tensorflow code triggers return type errors, silence those for now
+extra_compile_args += ['-Wno-return-type']
+
+ext = setuptools.Extension('warpctc_tensorflow.kernels',
+                           sources = ['src/ctc_op_kernel.cc'],
+                           language = 'c++',
+                           include_dirs = include_dirs,
+                           library_dirs = [warp_ctc_path],
+                           runtime_library_dirs = [warp_ctc_path],
+                           libraries = ['warpctc'],
+                           extra_compile_args = extra_compile_args)
+
+class build_tf_ext(orig_build_ext):
+    def build_extensions(self):
+        self.compiler.compiler_so.remove('-Wstrict-prototypes')
+        orig_build_ext.build_extensions(self)
+
+import unittest
+def discover_test_suite():
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover('tests', pattern='test_*.py')
+    return test_suite
+
+setuptools.setup(
+    name = "warpctc_tensorflow",
+    version = "0.1",
+    description = "TensorFlow wrapper for warp-ctc",
+    url = "https://github.com/baidu-research/warp-ctc",
+    author = "Jared Casper",
+    author_email = "jared.casper@baidu.com",
+    license = "Apache",
+    packages = ["warpctc_tensorflow"],
+    ext_modules = [ext],
+    cmdclass = {'build_ext': build_tf_ext},
+    test_suite = 'setup.discover_test_suite',
+)

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import os
+import platform
 import re
 import setuptools
 import sys
@@ -27,10 +28,15 @@ if "TENSORFLOW_SRC_PATH" not in os.environ:
           file=sys.stderr)
     sys.exit(1)
 
+if platform.system() == 'Darwin':
+    lib_ext = ".dylib"
+else:
+    lib_ext = ".so"
+
 warp_ctc_path = "../build"
 if "WARP_CTC_PATH" in os.environ:
     warp_ctc_path = os.environ["WARP_CTC_PATH"]
-if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc.so")):
+if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc"+lib_ext)):
     print(("Could not find libwarpctc.so in {}.\n"
            "Build warp-ctc and set WARP_CTC_PATH to the location of"
            " libwarpctc.so (default is '../build')").format(warp_ctc_path),

--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -1,5 +1,7 @@
 """setup.py script for warp-ctc TensorFlow wrapper"""
 
+from __future__ import print_function
+
 import os
 import re
 import setuptools

--- a/tensorflow_binding/src/ctc_op_kernel.cc
+++ b/tensorflow_binding/src/ctc_op_kernel.cc
@@ -136,6 +136,7 @@ class CTCLossOp : public tf::OpKernel {
         //auto cuda_stream = //perftools::gputools::cuda::AsCUDAStreamValue(tf_stream);
         auto cuda_stream = ctx->eigen_device<Eigen::GpuDevice>().stream();
         auto options = ctcOptions{};
+        memset(&options, 0, sizeof(options));
         options.loc = CTC_GPU;
         options.stream = cuda_stream;
         options.blank_label = num_classes - 1;

--- a/tensorflow_binding/src/ctc_op_kernel.cc
+++ b/tensorflow_binding/src/ctc_op_kernel.cc
@@ -1,0 +1,178 @@
+//#include <Python.h>
+
+#define EIGEN_USE_GPU
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/kernels/bounds_check.h"
+#include "tensorflow/core/util/sparse/sparse_tensor.h"
+#include "tensorflow/stream_executor/cuda/cuda_stream.h"
+#include <cuda.h>
+
+#include "ctc.h"
+
+// static struct PyMethodDef pythonMethods[] = {
+//     {NULL, NULL, 0, NULL}
+// };
+
+// static struct PyModuleDef pythonModule = {
+//     PyModuleDef_HEAD_INIT,
+//     "warpctc_tensorflow.kernels",
+//     NULL,
+//     -1,
+//     pythonMethods
+// };
+
+// PyMODINIT_FUNC
+// PyInit_kernels(void)
+// {
+//     return PyModule_Create(&pythonModule);
+// }
+
+namespace tf = tensorflow;
+
+namespace warp_ctc {
+
+class CTCLossOp : public tf::OpKernel {
+  public:
+    explicit CTCLossOp(tf::OpKernelConstruction* ctx) : tf::OpKernel(ctx) {
+    }
+
+    void Compute(tf::OpKernelContext* ctx) override {
+        // most of this is a copy/paste from the main tensorflow kernel
+
+        const tf::Tensor* inputs;
+        const tf::Tensor* labels_indices;
+        const tf::Tensor* labels_values;
+        const tf::Tensor* seq_len;
+        OP_REQUIRES_OK(ctx, ctx->input("inputs", &inputs));
+        OP_REQUIRES_OK(ctx, ctx->input("labels_indices", &labels_indices));
+        OP_REQUIRES_OK(ctx, ctx->input("labels_values", &labels_values));
+        OP_REQUIRES_OK(ctx, ctx->input("sequence_length", &seq_len));
+
+        OP_REQUIRES(ctx, inputs->shape().dims() == 3,
+                    tf::errors::InvalidArgument("inputs is not a 3-Tensor"));
+        OP_REQUIRES(ctx, tf::TensorShapeUtils::IsVector(seq_len->shape()),
+                    tf::errors::InvalidArgument("sequence_length is not a vector"));
+        OP_REQUIRES(ctx, tf::TensorShapeUtils::IsMatrix(labels_indices->shape()),
+                    tf::errors::InvalidArgument("labels_indices is not a matrix"));
+        OP_REQUIRES(ctx, tf::TensorShapeUtils::IsVector(labels_values->shape()),
+                    tf::errors::InvalidArgument("labels_values is not a vector"));
+
+        const tf::TensorShape& inputs_shape = inputs->shape();
+        const tf::int64 max_time = inputs_shape.dim_size(0);
+        const tf::int64 batch_size = inputs_shape.dim_size(1);
+        const tf::int64 num_classes_raw = inputs_shape.dim_size(2);
+        OP_REQUIRES(
+                ctx, tf::FastBoundsCheck(num_classes_raw, std::numeric_limits<int>::max()),
+                tf::errors::InvalidArgument("num_classes cannot exceed max int"));
+        const int num_classes = static_cast<const int>(num_classes_raw);
+
+        OP_REQUIRES(
+                ctx, batch_size == seq_len->dim_size(0),
+                tf::errors::InvalidArgument("len(sequence_length) != batch_size.  ",
+                                            "len(sequence_length):  ", seq_len->dim_size(0),
+                                            " batch_size: ", batch_size));
+        auto seq_len_t = seq_len->vec<int32_t>();
+
+        OP_REQUIRES(ctx, labels_indices->dim_size(0) == labels_values->dim_size(0),
+                    tf::errors::InvalidArgument(
+                            "labels_indices and labels_values must contain the "
+                            "same number of rows, but saw shapes: ",
+                            labels_indices->shape().DebugString(), " vs. ",
+                            labels_values->shape().DebugString()));
+
+        tf::TensorShape labels_shape({batch_size, max_time});
+        std::vector<tf::int64> order{0, 1};
+        tf::sparse::SparseTensor labels_sp(*labels_indices, *labels_values,
+                                       labels_shape, order);
+
+        tf::Status labels_sp_valid = labels_sp.IndicesValid();
+        OP_REQUIRES(ctx, labels_sp_valid.ok(),
+                    tf::errors::InvalidArgument("label SparseTensor is not valid: ",
+                                            labels_sp_valid.error_message()));
+
+        // first difference from tensorflows... getting the labels together
+        auto label_lengths = std::vector<int>{};
+        for (const auto& g : labels_sp.group({0})) {  // iterate by batch
+            const tf::int64 batch_indices = g.group()[0];
+            OP_REQUIRES(ctx, tf::FastBoundsCheck(batch_indices, batch_size),
+                        tf::errors::InvalidArgument("labels batch index must be between ",
+                                                    0, " and ", batch_size, " but saw: ",
+                                                    batch_indices));
+            
+            auto values = g.values<int32_t>();
+            label_lengths.push_back(values.size());
+        }
+        auto label_values_t = labels_values->vec<int>();
+
+
+        OP_REQUIRES(ctx, static_cast<size_t>(batch_size) == label_lengths.size(),
+                    tf::errors::InvalidArgument("len(labels) != batch_size.  ",
+                                                "len(labels):  ", label_lengths.size(),
+                                                " batch_size: ", batch_size));
+
+        for (int b = 0; b < batch_size; ++b) {
+            OP_REQUIRES(
+                    ctx, seq_len_t(b) <= max_time,
+                    tf::errors::InvalidArgument("sequence_length(", b, ") <= ", max_time));
+        }
+
+        tf::Tensor* loss = nullptr;
+        OP_REQUIRES_OK(ctx, ctx->allocate_output("loss", seq_len->shape(), &loss));
+        auto loss_t = loss->vec<float>();
+
+        tf::Tensor* gradient;
+        OP_REQUIRES_OK(ctx,
+                       ctx->allocate_output("gradient", inputs_shape, &gradient));
+        auto gradient_t = gradient->tensor<float, 3>();
+        cudaMemset(gradient_t.data(), 0, gradient->NumElements()*sizeof(float));
+
+        auto inputs_t = inputs->tensor<float, 3>();
+
+        // second difference, don't need to make a map of input and gradients, just use them directly
+
+
+        // warp-ctc specific stuff from here on out
+        //auto tf_stream = ctx->device()->tensorflow_gpu_device_info()->stream;
+        //auto cuda_stream = //perftools::gputools::cuda::AsCUDAStreamValue(tf_stream);
+        auto cuda_stream = ctx->eigen_device<Eigen::GpuDevice>().stream();
+        auto options = ctcOptions{};
+        options.loc = CTC_GPU;
+        options.stream = cuda_stream;
+        options.blank_label = num_classes - 1;
+
+        size_t workspace_size_bytes;
+        auto warp_status = get_workspace_size(label_lengths.data(), seq_len_t.data(),
+                                              num_classes, batch_size,
+                                              options, &workspace_size_bytes);
+        // TODO error check warp_status
+
+        auto workspace_shape = tf::TensorShape{static_cast<int64_t>(workspace_size_bytes)};
+        tf::Tensor workspace;
+        OP_REQUIRES_OK(ctx, ctx->allocate_temp(tf::DT_UINT8, workspace_shape, &workspace));
+        auto workspace_t = workspace.flat<uint8_t>();
+
+        warp_status = compute_ctc_loss(inputs_t.data(),
+                                       gradient_t.data(),
+                                       label_values_t.data(),
+                                       label_lengths.data(),
+                                       seq_len_t.data(),
+                                       num_classes, batch_size,
+                                       loss_t.data(), workspace_t.data(), options);
+        
+        OP_REQUIRES(ctx, warp_status == CTC_STATUS_SUCCESS,
+                    tf::errors::Internal("warp_ctc error: ", ctcGetStatusString(warp_status)));
+
+    }
+
+
+};
+
+REGISTER_KERNEL_BUILDER(Name("CTCLoss")
+                        .Device(::tensorflow::DEVICE_GPU)
+                        .HostMemory("labels_indices")
+                        .HostMemory("labels_values")
+                        .HostMemory("sequence_length")
+                        .HostMemory("loss"),
+                        CTCLossOp);
+
+}

--- a/tensorflow_binding/src/ctc_op_kernel.cc
+++ b/tensorflow_binding/src/ctc_op_kernel.cc
@@ -214,3 +214,4 @@ REGISTER_KERNEL_BUILDER(Name("CTCLoss")
                         CTCLossOpGPU);
 
 }
+#undef EIGEN_USE_GPU

--- a/tensorflow_binding/src/ctc_op_kernel.cc
+++ b/tensorflow_binding/src/ctc_op_kernel.cc
@@ -14,6 +14,18 @@ namespace warp_ctc {
 class CTCLossOpBase : public tf::OpKernel {
   public:
     explicit CTCLossOpBase(tf::OpKernelConstruction* ctx) : tf::OpKernel(ctx) {
+        bool preprocess_collapse_repeated;
+        OP_REQUIRES_OK(ctx, ctx->GetAttr("preprocess_collapse_repeated",
+                                         &preprocess_collapse_repeated));
+        OP_REQUIRES(ctx, preprocess_collapse_repeated == false,
+                    tf::errors::InvalidArgument("preprocess collapse repeated is not currently "
+                                                "supported in the WarpCTC kernel."));
+
+        bool ctc_merge_repeated;
+        OP_REQUIRES_OK(ctx, ctx->GetAttr("ctc_merge_repeated", &ctc_merge_repeated));
+        OP_REQUIRES(ctx, ctc_merge_repeated == true,
+                    tf::errors::InvalidArgument("ctc_merge_repeated == false is not currently "
+                                                "supported. WarpCTC always merges repeated symbols."));
     }
 
     void Compute(tf::OpKernelContext* ctx) override {

--- a/tensorflow_binding/src/ctc_op_kernel.cc
+++ b/tensorflow_binding/src/ctc_op_kernel.cc
@@ -166,7 +166,6 @@ class CTCLossOpCPU : public CTCLossOpBase {
 
     ctcOptions create_options(tf::OpKernelContext* ctx) override {
         auto options = ctcOptions{};
-        memset(&options, 0, sizeof(options));
         options.loc = CTC_CPU;
         options.num_threads = ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
         return options;
@@ -193,7 +192,6 @@ class CTCLossOpGPU : public CTCLossOpBase {
     ctcOptions create_options(tf::OpKernelContext* ctx) override {
         auto cuda_stream = ctx->eigen_device<Eigen::GpuDevice>().stream();
         auto options = ctcOptions{};
-        memset(&options, 0, sizeof(options));
         options.loc = CTC_GPU;
         options.stream = cuda_stream;
         return options;

--- a/tensorflow_binding/src/warpctc_op.cc
+++ b/tensorflow_binding/src/warpctc_op.cc
@@ -44,7 +44,7 @@ class WarpCTCOpBase : public tf::OpKernel {
         OP_REQUIRES(ctx, tf::TensorShapeUtils::IsVector(input_lengths->shape()),
                      tf::errors::InvalidArgument("input_lengths is not a vector"));
 
-        const auto acts_shape = activations->shape();
+        const auto& acts_shape = activations->shape();
         const auto max_time = acts_shape.dim_size(0);
         const auto batch_size = acts_shape.dim_size(1);
         const auto num_classes_raw = acts_shape.dim_size(2);

--- a/tensorflow_binding/src/warpctc_op.cc
+++ b/tensorflow_binding/src/warpctc_op.cc
@@ -85,7 +85,7 @@ class WarpCTCOpBase : public tf::OpKernel {
         tf::Tensor* grads = nullptr;
         OP_REQUIRES_OK(ctx, ctx->allocate_output("gradients", activations->shape(),
                                                  &grads));
-        setZero(grads);
+        set_zero(grads);
         auto grads_t = grads->tensor<float, 3>();
 
         auto options = create_options(ctx);
@@ -120,7 +120,7 @@ class WarpCTCOpBase : public tf::OpKernel {
 
     }
   private:
-    virtual void setZero(tf::Tensor* t) = 0;
+    virtual void set_zero(tf::Tensor* t) = 0;
     virtual ctcOptions create_options(tf::OpKernelContext* ctx) = 0;
 };
 
@@ -130,7 +130,7 @@ class WarpCTCOpCPU : public WarpCTCOpBase {
     }
 
   private:
-    void setZero(tf::Tensor* t) override {
+    void set_zero(tf::Tensor* t) override {
         t->flat<float>().setZero();
     }
 
@@ -149,7 +149,7 @@ class WarpCTCOpGPU : public WarpCTCOpBase {
     }
 
   private:
-    void setZero(tf::Tensor* t) override {
+    void set_zero(tf::Tensor* t) override {
         cudaMemset(t->flat<float>().data(), 0, t->NumElements()*sizeof(float));
     }
 
@@ -164,8 +164,7 @@ class WarpCTCOpGPU : public WarpCTCOpBase {
 };
 
 REGISTER_KERNEL_BUILDER(Name("WarpCTC").Device(::tensorflow::DEVICE_CPU), WarpCTCOpCPU);
-REGISTER_KERNEL_BUILDER(Name("WarpCTC")
-                        .Device(::tensorflow::DEVICE_GPU)
+REGISTER_KERNEL_BUILDER(Name("WarpCTC").Device(::tensorflow::DEVICE_GPU)
                         .HostMemory("flat_labels")
                         .HostMemory("label_lengths")
                         .HostMemory("input_lengths")

--- a/tensorflow_binding/src/warpctc_op.cc
+++ b/tensorflow_binding/src/warpctc_op.cc
@@ -1,0 +1,169 @@
+#define EIGEN_USE_GPU
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/allocator.h"
+
+#include "ctc.h"
+
+
+REGISTER_OP("WarpCTC")
+    .Input("data: float32")
+    .Input("data_lengths: int32")
+    .Input("flat_labels: int32")
+    .Input("label_lengths: int32")
+    .Attr("alphabet_size: int")
+    .Output("loss: float32")
+    .Output("gradient: float32");
+
+using namespace tensorflow;
+
+class WarpCTCOpCPU : public OpKernel {
+ public:
+  explicit WarpCTCOpCPU(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("alphabet_size", &alphabet_size_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // Grab the input tensors
+    const Tensor& data_t = context->input(0);
+    const Tensor& data_lens_t = context->input(1);
+    const Tensor& labels_t = context->input(2);
+    const Tensor& label_lens_t = context->input(3);
+    auto data = data_t.flat<float>();
+    auto data_lens = data_lens_t.flat<int>();
+    auto labels = labels_t.flat<int>();
+    auto label_lens = label_lens_t.flat<int>();
+    int alphabet_size = alphabet_size_;
+    int n_minibatches = data_t.dim_size(1);
+
+    auto options = ctcOptions{};
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_CPU;
+    options.num_threads = context->device()->tensorflow_cpu_worker_threads()->num_threads;
+
+    size_t cpu_alloc_bytes;
+    ctcStatus_t stat_alloc = get_workspace_size(label_lens.data(), data_lens.data(),
+                                          alphabet_size, n_minibatches, options,
+                                          &cpu_alloc_bytes);
+
+    OP_REQUIRES(context, (stat_alloc == CTC_STATUS_SUCCESS),
+                errors::Internal("Error in CTC memory estimation"))
+
+    // allocate scratch space for ctc computation
+    Allocator* a = context->device()->GetAllocator(AllocatorAttributes());
+
+    void* scratch = a->AllocateRaw(1, cpu_alloc_bytes);
+
+    // allocate gradient tensor
+    Tensor* gradients = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(1, data_t.shape(),
+                                                     &gradients));
+    auto grads = gradients->flat<float>();
+
+    // compute CTC
+    std::vector<float> costs(n_minibatches);
+    ctcStatus_t stat_compute = compute_ctc_loss(data.data(),
+                                                grads.data(),
+                                                labels.data(),
+                                                label_lens.data(),
+                                                data_lens.data(),
+                                                alphabet_size,
+                                                n_minibatches,
+                                                costs.data(),
+                                                scratch,
+                                                options);
+    // std::raise(SIGINT);
+
+    a->DeallocateRaw(scratch);
+
+    OP_REQUIRES(context, (stat_compute == CTC_STATUS_SUCCESS),
+                errors::Internal("Error in CTC computation"))
+
+    Tensor* loss_t = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({n_minibatches}), &loss_t));
+    auto loss = loss_t->flat<float>();
+    for (int i = 0; i < n_minibatches; ++i) {
+      loss(i) = costs[i];
+    }
+  }
+ private:
+  int alphabet_size_;
+};
+
+class WarpCTCOpGPU : public OpKernel {
+ public:
+  explicit WarpCTCOpGPU(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("alphabet_size", &alphabet_size_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+
+    const Tensor& data_t = ctx->input(0);
+    const Tensor& data_lens_t = ctx->input(1);
+    const Tensor& labels_t = ctx->input(2);
+    const Tensor& label_lens_t = ctx->input(3);
+    auto data = data_t.flat<float>();
+    auto data_lens = data_lens_t.flat<int32>();
+    auto labels = labels_t.flat<int32>();
+    auto label_lens = label_lens_t.flat<int32>();
+    int alphabet_size = alphabet_size_;
+    int n_minibatches = data_t.dim_size(1);
+
+    auto cuda_stream = ctx->eigen_device<Eigen::GpuDevice>().stream();
+    auto options = ctcOptions{};
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.stream = cuda_stream;
+
+    size_t workspace_size_bytes;
+    ctcStatus_t stat_alloc = get_workspace_size(label_lens.data(), data_lens.data(),
+                                                alphabet_size, n_minibatches, options,
+                                                &workspace_size_bytes);
+    OP_REQUIRES(ctx, (stat_alloc == CTC_STATUS_SUCCESS),
+                errors::Internal("Error in CTC memory estimation"));
+
+    //  allocate scratch space for ctc computation
+    auto workspace_shape = TensorShape{static_cast<int64_t>(workspace_size_bytes)};
+    Tensor workspace;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_UINT8, workspace_shape, &workspace));
+    auto workspace_t = workspace.flat<uint8_t>();
+
+    // allocate gradient tensor
+    Tensor* loss = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output("loss", data_lens_t.shape(), &loss));
+    auto loss_t = loss->vec<float>();
+    
+    Tensor* gradient;
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_output("gradient", data_t.shape(), &gradient));
+    auto gradient_t = gradient->tensor<float, 3>();
+    cudaMemset(gradient_t.data(), 0, gradient->NumElements()*sizeof(float));
+
+    ctcStatus_t stat_compute = compute_ctc_loss(data.data(),
+                                                gradient_t.data(),
+                                                labels.data(),
+                                                label_lens.data(),
+                                                data_lens.data(),
+                                                alphabet_size,
+                                                n_minibatches,
+                                                loss_t.data(),
+                                                workspace_t.data(),
+                                                options);
+
+    OP_REQUIRES(ctx, (stat_compute == CTC_STATUS_SUCCESS),
+                errors::Internal("Error in CTC computation"));
+  }
+ private:
+  int alphabet_size_;
+};
+
+#undef EIGEN_USE_GPU
+
+REGISTER_KERNEL_BUILDER(Name("WarpCTC").Device(DEVICE_CPU), WarpCTCOpCPU);
+REGISTER_KERNEL_BUILDER(Name("WarpCTC")
+                        .Device(DEVICE_GPU)
+                        .HostMemory("flat_labels")
+                        .HostMemory("label_lengths")
+                        .HostMemory("data_lengths")
+                        .HostMemory("loss"),
+                        WarpCTCOpGPU);

--- a/tensorflow_binding/src/warpctc_op.cc
+++ b/tensorflow_binding/src/warpctc_op.cc
@@ -143,7 +143,6 @@ class WarpCTCOpCPU : public WarpCTCOpBase {
 
     ctcOptions create_options(tf::OpKernelContext* ctx) override {
         auto options = ctcOptions{};
-        memset(&options, 0, sizeof(options));
         options.loc = CTC_CPU;
         options.num_threads = ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
         return options;
@@ -167,7 +166,6 @@ class WarpCTCOpGPU : public WarpCTCOpBase {
     ctcOptions create_options(tf::OpKernelContext* ctx) override {
         auto cuda_stream = ctx->eigen_device<Eigen::GpuDevice>().stream();
         auto options = ctcOptions{};
-        memset(&options, 0, sizeof(options));
         options.loc = CTC_GPU;
         options.stream = cuda_stream;
         return options;

--- a/tensorflow_binding/tests/test_ctc_loss_op.py
+++ b/tensorflow_binding/tests/test_ctc_loss_op.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 import warpctc_tensorflow
+from tensorflow.python.client import device_lib
+
 
 def SimpleSparseTensorFrom(x):
   """Create a very simple SparseTensor with dimensions (batch, time).
@@ -44,6 +46,9 @@ def SimpleSparseTensorFrom(x):
 
   return tf.SparseTensor(x_ix, x_val, x_shape)
 
+def is_gpu_available():
+  """Returns whether TensorFlow can access a GPU."""
+  return any(x.device_type == 'GPU' for x in device_lib.list_local_devices())
 
 class CTCLossTest(tf.test.TestCase):
 
@@ -218,7 +223,10 @@ class CTCLossTest(tf.test.TestCase):
     self._testBasic(use_gpu=False)
 
   def testBasicGPU(self):
-    self._testBasic(use_gpu=True)
+    if (is_gpu_available()):
+      self._testBasic(use_gpu=True)
+    else:
+      print("Skipping GPU test, no gpus available")
 
 if __name__ == "__main__":
   tf.test.main()

--- a/tensorflow_binding/tests/test_ctc_loss_op.py
+++ b/tensorflow_binding/tests/test_ctc_loss_op.py
@@ -1,0 +1,209 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for tensorflow.ctc_ops.ctc_decoder_ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+import warpctc_tensorflow
+
+def SimpleSparseTensorFrom(x):
+  """Create a very simple SparseTensor with dimensions (batch, time).
+
+  Args:
+    x: a list of lists of type int
+
+  Returns:
+    x_ix and x_val, the indices and values of the SparseTensor<2>.
+  """
+  x_ix = []
+  x_val = []
+  for batch_i, batch in enumerate(x):
+    for time, val in enumerate(batch):
+      x_ix.append([batch_i, time])
+      x_val.append(val)
+  x_shape = [len(x), np.asarray(x_ix).max(0)[1]+1]
+  x_ix = tf.constant(x_ix, tf.int64)
+  x_val = tf.constant(x_val, tf.int32)
+  x_shape = tf.constant(x_shape, tf.int64)
+
+  return tf.SparseTensor(x_ix, x_val, x_shape)
+
+
+class CTCLossTest(tf.test.TestCase):
+
+  def _testCTCLoss(self, inputs, seq_lens, labels,
+                   loss_truth, grad_truth, expected_err_re=None):
+    self.assertEqual(len(inputs), len(grad_truth))
+
+    inputs_t = tf.constant(inputs)
+
+    log_dev_placement = False
+    tfconfig = tf.ConfigProto(log_device_placement=log_dev_placement,
+                              allow_soft_placement=False)
+    with self.test_session(force_gpu=True, config=tfconfig) as sess:
+      loss = tf.nn.ctc_loss(inputs=inputs_t,
+                            labels=labels,
+                            sequence_length=seq_lens)
+      grad = tf.gradients(loss, [inputs_t])[0]
+
+      self.assertShapeEqual(loss_truth, loss)
+      self.assertShapeEqual(grad_truth, grad)
+
+      if expected_err_re is None:
+        (tf_loss, tf_grad) = sess.run([loss, grad])
+        self.assertAllClose(tf_loss, loss_truth, rtol=1e-4, atol=1e-4)
+        self.assertAllClose(tf_grad, grad_truth, rtol=1e-4, atol=1e-4)
+      else:
+        with self.assertRaisesOpError(expected_err_re):
+          sess.run([loss, grad])
+
+  def testBasic(self):
+    """Test two batch entries."""
+    # Input and ground truth from Alex Graves' implementation.
+    #
+    #### Batch entry 0 #####
+    # targets: 0 1 2 1 0
+    # outputs:
+    # 0 0.633766 0.221185 0.0917319 0.0129757 0.0142857 0.0260553
+    # 1 0.111121 0.588392 0.278779 0.0055756 0.00569609 0.010436
+    # 2 0.0357786 0.633813 0.321418 0.00249248 0.00272882 0.0037688
+    # 3 0.0663296 0.643849 0.280111 0.00283995 0.0035545 0.00331533
+    # 4 0.458235 0.396634 0.123377 0.00648837 0.00903441 0.00623107
+    # alpha:
+    # 0 -3.64753 -0.456075 -inf -inf -inf -inf -inf -inf -inf -inf -inf
+    # 1 -inf -inf -inf -0.986437 -inf -inf -inf -inf -inf -inf -inf
+    # 2 -inf -inf -inf -inf -inf -2.12145 -inf -inf -inf -inf -inf
+    # 3 -inf -inf -inf -inf -inf -inf -inf -2.56174 -inf -inf -inf
+    # 4 -inf -inf -inf -inf -inf -inf -inf -inf -inf -3.34211 -inf
+    # beta:
+    # 0 -inf -2.88604 -inf -inf -inf -inf -inf -inf -inf -inf -inf
+    # 1 -inf -inf -inf -2.35568 -inf -inf -inf -inf -inf -inf -inf
+    # 2 -inf -inf -inf -inf -inf -1.22066 -inf -inf -inf -inf -inf
+    # 3 -inf -inf -inf -inf -inf -inf -inf -0.780373 -inf -inf -inf
+    # 4 -inf -inf -inf -inf -inf -inf -inf -inf -inf 0 0
+    # prob: -3.34211
+    # outputDerivs:
+    # 0 -0.366234 0.221185 0.0917319 0.0129757 0.0142857 0.0260553
+    # 1 0.111121 -0.411608 0.278779 0.0055756 0.00569609 0.010436
+    # 2 0.0357786 0.633813 -0.678582 0.00249248 0.00272882 0.0037688
+    # 3 0.0663296 -0.356151 0.280111 0.00283995 0.0035545 0.00331533
+    # 4 -0.541765 0.396634 0.123377 0.00648837 0.00903441 0.00623107
+    #
+    #### Batch entry 1 #####
+    #
+    # targets: 0 1 1 0
+    # outputs:
+    # 0 0.30176 0.28562 0.0831517 0.0862751 0.0816851 0.161508
+    # 1 0.24082 0.397533 0.0557226 0.0546814 0.0557528 0.19549
+    # 2 0.230246 0.450868 0.0389607 0.038309 0.0391602 0.202456
+    # 3 0.280884 0.429522 0.0326593 0.0339046 0.0326856 0.190345
+    # 4 0.423286 0.315517 0.0338439 0.0393744 0.0339315 0.154046
+    # alpha:
+    # 0 -1.8232 -1.19812 -inf -inf -inf -inf -inf -inf -inf
+    # 1 -inf -2.19315 -2.83037 -2.1206 -inf -inf -inf -inf -inf
+    # 2 -inf -inf -inf -2.03268 -3.71783 -inf -inf -inf -inf
+    # 3 -inf -inf -inf -inf -inf -4.56292 -inf -inf -inf
+    # 4 -inf -inf -inf -inf -inf -inf -inf -5.42262 -inf
+    # beta:
+    # 0 -inf -4.2245 -inf -inf -inf -inf -inf -inf -inf
+    # 1 -inf -inf -inf -3.30202 -inf -inf -inf -inf -inf
+    # 2 -inf -inf -inf -inf -1.70479 -0.856738 -inf -inf -inf
+    # 3 -inf -inf -inf -inf -inf -0.859706 -0.859706 -0.549337 -inf
+    # 4 -inf -inf -inf -inf -inf -inf -inf 0 0
+    # prob: -5.42262
+    # outputDerivs:
+    # 0 -0.69824 0.28562 0.0831517 0.0862751 0.0816851 0.161508
+    # 1 0.24082 -0.602467 0.0557226 0.0546814 0.0557528 0.19549
+    # 2 0.230246 0.450868 0.0389607 0.038309 0.0391602 -0.797544
+    # 3 0.280884 -0.570478 0.0326593 0.0339046 0.0326856 0.190345
+    # 4 -0.576714 0.315517 0.0338439 0.0393744 0.0339315 0.154046
+
+    # max_time_steps == 7
+    depth = 6
+
+    # seq_len_0 == 5
+    targets_0 = [0, 1, 2, 1, 0]
+    loss_log_prob_0 = -3.34211
+    # dimensions are time x depth
+    input_prob_matrix_0 = np.asarray(
+        [[0.633766, 0.221185, 0.0917319, 0.0129757, 0.0142857, 0.0260553],
+         [0.111121, 0.588392, 0.278779, 0.0055756, 0.00569609, 0.010436],
+         [0.0357786, 0.633813, 0.321418, 0.00249248, 0.00272882, 0.0037688],
+         [0.0663296, 0.643849, 0.280111, 0.00283995, 0.0035545, 0.00331533],
+         [0.458235, 0.396634, 0.123377, 0.00648837, 0.00903441, 0.00623107]],
+        dtype=np.float32)
+    input_log_prob_matrix_0 = np.log(input_prob_matrix_0)
+    gradient_log_prob_0 = np.asarray(
+        [[-0.366234, 0.221185, 0.0917319, 0.0129757, 0.0142857, 0.0260553],
+         [0.111121, -0.411608, 0.278779, 0.0055756, 0.00569609, 0.010436],
+         [0.0357786, 0.633813, -0.678582, 0.00249248, 0.00272882, 0.0037688],
+         [0.0663296, -0.356151, 0.280111, 0.00283995, 0.0035545, 0.00331533],
+         [-0.541765, 0.396634, 0.123377, 0.00648837, 0.00903441, 0.00623107]],
+        dtype=np.float32)
+
+    # seq_len_1 == 5
+    targets_1 = [0, 1, 1, 0]
+    loss_log_prob_1 = -5.42262
+    # dimensions are time x depth
+
+    input_prob_matrix_1 = np.asarray(
+        [[0.30176, 0.28562, 0.0831517, 0.0862751, 0.0816851, 0.161508],
+         [0.24082, 0.397533, 0.0557226, 0.0546814, 0.0557528, 0.19549],
+         [0.230246, 0.450868, 0.0389607, 0.038309, 0.0391602, 0.202456],
+         [0.280884, 0.429522, 0.0326593, 0.0339046, 0.0326856, 0.190345],
+         [0.423286, 0.315517, 0.0338439, 0.0393744, 0.0339315, 0.154046]],
+        dtype=np.float32)
+    input_log_prob_matrix_1 = np.log(input_prob_matrix_1)
+    gradient_log_prob_1 = np.asarray(
+        [[-0.69824, 0.28562, 0.0831517, 0.0862751, 0.0816851, 0.161508],
+         [0.24082, -0.602467, 0.0557226, 0.0546814, 0.0557528, 0.19549],
+         [0.230246, 0.450868, 0.0389607, 0.038309, 0.0391602, -0.797544],
+         [0.280884, -0.570478, 0.0326593, 0.0339046, 0.0326856, 0.190345],
+         [-0.576714, 0.315517, 0.0338439, 0.0393744, 0.0339315, 0.154046]],
+        dtype=np.float32)
+
+    # len max_time_steps array of 2 x depth matrices
+    inputs = [np.vstack([input_log_prob_matrix_0[t, :],
+                         input_log_prob_matrix_1[t, :]])
+              for t in range(5)] + 2 * [np.nan*np.ones((2, depth), np.float32)]
+
+    # convert inputs into [max_time x batch_size x depth tensor] Tensor
+    inputs = np.asarray(inputs, dtype=np.float32)
+
+    # len batch_size array of label vectors
+    labels = SimpleSparseTensorFrom([targets_0, targets_1])
+
+    # batch_size length vector of sequence_lengths
+    seq_lens = np.array([5, 5], dtype=np.int32)
+
+    # output: batch_size length vector of negative log probabilities
+    loss_truth = np.array([-loss_log_prob_0, -loss_log_prob_1], np.float32)
+
+    # output: len max_time_steps array of 2 x depth matrices
+    grad_truth = [np.vstack([gradient_log_prob_0[t, :],
+                             gradient_log_prob_1[t, :]])
+                  for t in range(5)] + 2 * [np.zeros((2, depth), np.float32)]
+
+    # convert grad_truth into [max_time x batch_size x depth] Tensor
+    grad_truth = np.asarray(grad_truth, dtype=np.float32)
+
+    self._testCTCLoss(inputs, seq_lens, labels, loss_truth, grad_truth)
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorflow_binding/tests/test_warpctc_op.py
+++ b/tensorflow_binding/tests/test_warpctc_op.py
@@ -1,0 +1,153 @@
+import tensorflow as tf
+import numpy as np
+from warpctc_tensorflow import ctc
+
+class WarpCTCTest(tf.test.TestCase):
+
+    def _run_ctc_cpu(self, data, data_lengths,
+                     flat_labels, label_lengths,
+                     alphabet_size, expected_loss,
+                     expected_gradients, expected_error=None):
+        self.assertEquals(data.shape, expected_gradients.shape)
+        data_t = tf.constant(data)
+        data_lengths_t = tf.constant(data_lengths)
+        flat_labels_t = tf.constant(flat_labels)
+        label_lengths_t = tf.constant(label_lengths)
+        loss = ctc(data_t, data_lengths=data_lengths_t,
+                   flat_labels=flat_labels_t,
+                   label_lengths=label_lengths_t,
+                   alphabet_size=alphabet_size)
+
+        grad = tf.gradients(loss, [data_t])[0]
+        self.assertShapeEqual(expected_loss, loss)
+        self.assertShapeEqual(expected_gradients, grad)
+        # Note: using use_gpu=False seems to not work
+        # it runs the GPU version instead, which
+        # errors out.
+        config = tf.ConfigProto(device_count={'GPU': 0})
+        with self.test_session(config=config) as sess:
+            if expected_error is None:
+                (tf_loss, tf_grad) = sess.run([loss, grad])
+                self.assertAllClose(tf_loss, expected_loss, atol=1e-6)
+                self.assertAllClose(tf_grad, expected_gradients, atol=1e-6)
+            else:
+                with self.assertRaisesOpError(expected_error):
+                    sess.run([loss, grad])
+
+    def _run_ctc_gpu(self, data, data_lengths,
+                     flat_labels, label_lengths,
+                     alphabet_size, expected_loss,
+                     expected_gradients, expected_error=None):
+        self.assertEquals(data.shape, expected_gradients.shape)
+        data_t = tf.constant(data, dtype=tf.float32)
+        data_lengths_t = tf.constant(data_lengths, dtype=tf.int32)
+        flat_labels_t = tf.constant(flat_labels, dtype=tf.int32)
+        label_lengths_t = tf.constant(label_lengths, dtype=tf.int32)
+        loss = ctc(data_t, data_lengths=data_lengths_t,
+                   flat_labels=flat_labels_t,
+                   label_lengths=label_lengths_t,
+                   alphabet_size=alphabet_size)
+        grad = tf.gradients(loss, [data_t])[0]
+        self.assertShapeEqual(expected_loss, loss)
+        self.assertShapeEqual(expected_gradients, grad)
+        log_dev_placement = True
+        tfconfig = tf.ConfigProto(log_device_placement=log_dev_placement,
+                                  allow_soft_placement=False)
+        with self.test_session(use_gpu=True, force_gpu=True, config=tfconfig) as sess:
+            if expected_error is None:
+                (tf_loss, tf_grad) = sess.run([loss, grad])
+                self.assertAllClose(tf_loss, expected_loss, atol=1e-6)
+                self.assertAllClose(tf_grad, expected_gradients, atol=1e-6)
+            else:
+                with self.assertRaisesOpError(expected_error):
+                    sess.run([loss, grad])
+
+    def test_basic_cpu(self):
+        # Softmax activations for the following inputs:
+        activations = np.array([
+            [0.1, 0.6, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.6, 0.1, 0.1]
+        ], dtype=np.float32)
+
+        alphabet_size = 5
+        # dimensions should be t, n, p: (t timesteps, n minibatches,
+        # p prob of each alphabet). This is one instance, so expand
+        # dimensions in the middle
+        data = np.expand_dims(activations, 1)
+        labels = np.asarray([1, 2], dtype=np.int32)
+        expected_loss = np.asarray([2.46286], dtype=np.float32)
+        gradients = np.asarray([
+            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
+            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
+        ], dtype=np.float32)
+        expected_gradients = np.expand_dims(gradients, 1)
+        label_lengths = np.asarray([2], dtype=np.int32)
+        data_lengths = np.asarray([2], dtype=np.int32)
+
+        self._run_ctc_cpu(data, data_lengths=data_lengths,
+                          flat_labels=labels, label_lengths=label_lengths,
+                          alphabet_size=alphabet_size,
+                          expected_loss=expected_loss,
+                          expected_gradients=expected_gradients)
+
+    def test_basic_gpu(self):
+        # Softmax activations for the following inputs:
+        activations = np.array([
+            [0.1, 0.6, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.6, 0.1, 0.1]
+        ], dtype=np.float32)
+
+        alphabet_size = 5
+        # dimensions should be t, n, p: (t timesteps, n minibatches,
+        # p prob of each alphabet). This is one instance, so expand
+        # dimensions in the middle
+        data = np.expand_dims(activations, 1)
+        labels = np.asarray([1, 2], dtype=np.int32)
+        expected_loss = np.asarray([2.46286], dtype=np.float32)
+        gradients = np.asarray([
+            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
+            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
+        ], dtype=np.float32)
+        expected_gradients = np.expand_dims(gradients, 1)
+        label_lengths = np.asarray([2], dtype=np.int32)
+        data_lengths = np.asarray([2], dtype=np.int32)
+        self._run_ctc_gpu(data, data_lengths=data_lengths,
+                          flat_labels=labels, label_lengths=label_lengths,
+                          alphabet_size=alphabet_size,
+                          expected_loss=expected_loss,
+                          expected_gradients=expected_gradients)
+
+    def test_multiple_batches(self):
+        activations = np.array([
+            [0.1, 0.6, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.6, 0.1, 0.1]
+        ], dtype=np.float32)
+
+        alphabet_size = 5
+        # dimensions should be t, n, p: (t timesteps, n minibatches,
+        # p prob of each alphabet). This is one instance, so expand
+        # dimensions in the middle
+        _data = np.expand_dims(activations, 1)
+        data = np.concatenate([_data, _data[...]], axis=1)
+        labels = np.asarray([1, 2, 1, 2], dtype=np.int32)
+        expected_loss = np.asarray([2.46286, 2.46286], dtype=np.float32)
+        gradients = np.asarray([
+            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
+            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
+        ], dtype=np.float32)
+        _expected_gradients = np.expand_dims(gradients, 1)
+        expected_gradients = np.concatenate(
+            [_expected_gradients, _expected_gradients[...]], axis=1)
+
+        label_lengths = np.asarray([2, 2], dtype=np.int32)
+        data_lengths = np.asarray([2, 2], dtype=np.int32)
+
+        self._run_ctc_cpu(data, data_lengths=data_lengths,
+                          flat_labels=labels, label_lengths=label_lengths,
+                          alphabet_size=alphabet_size,
+                          expected_loss=expected_loss,
+                          expected_gradients=expected_gradients)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorflow_binding/tests/test_warpctc_op.py
+++ b/tensorflow_binding/tests/test_warpctc_op.py
@@ -4,94 +4,82 @@ from warpctc_tensorflow import ctc
 
 class WarpCTCTest(tf.test.TestCase):
 
-    def _run_ctc_cpu(self, data, data_lengths,
-                     flat_labels, label_lengths,
-                     alphabet_size, expected_loss,
-                     expected_gradients, expected_error=None):
-        self.assertEquals(data.shape, expected_gradients.shape)
-        data_t = tf.constant(data)
-        data_lengths_t = tf.constant(data_lengths)
+    def _run_ctc(self, activations, input_lengths,
+                 flat_labels, label_lengths,
+                 expected_costs, expected_gradients,
+                 use_gpu=False, expected_error=None):
+        self.assertEquals(activations.shape, expected_gradients.shape)
+        activations_t = tf.constant(activations)
+        input_lengths_t = tf.constant(input_lengths)
         flat_labels_t = tf.constant(flat_labels)
         label_lengths_t = tf.constant(label_lengths)
-        loss = ctc(data_t, data_lengths=data_lengths_t,
-                   flat_labels=flat_labels_t,
-                   label_lengths=label_lengths_t,
-                   alphabet_size=alphabet_size)
+        costs = ctc(activations_t, input_lengths=input_lengths_t,
+                    flat_labels=flat_labels_t,
+                    label_lengths=label_lengths_t)
 
-        grad = tf.gradients(loss, [data_t])[0]
-        self.assertShapeEqual(expected_loss, loss)
+        grad = tf.gradients(costs, [activations_t])[0]
+
+        self.assertShapeEqual(expected_costs, costs)
+
         self.assertShapeEqual(expected_gradients, grad)
-        # Note: using use_gpu=False seems to not work
-        # it runs the GPU version instead, which
-        # errors out.
-        config = tf.ConfigProto(device_count={'GPU': 0})
-        with self.test_session(config=config) as sess:
+
+        log_dev_placement = False
+        if not use_gpu:
+            # Note: using use_gpu=False seems to not work
+            # it runs the GPU version instead
+            config = tf.ConfigProto(log_device_placement=log_dev_placement,
+                                    device_count={'GPU': 0})
+        else:
+            config = tf.ConfigProto(log_device_placement=log_dev_placement,
+                                    allow_soft_placement=False)
+
+        with self.test_session(use_gpu=use_gpu, force_gpu=use_gpu, config=config) as sess:
             if expected_error is None:
-                (tf_loss, tf_grad) = sess.run([loss, grad])
-                self.assertAllClose(tf_loss, expected_loss, atol=1e-6)
+                (tf_costs, tf_grad) = sess.run([costs, grad])
+                self.assertAllClose(tf_costs, expected_costs, atol=1e-6)
                 self.assertAllClose(tf_grad, expected_gradients, atol=1e-6)
             else:
                 with self.assertRaisesOpError(expected_error):
-                    sess.run([loss, grad])
+                    sess.run([costs, grad])
 
-    def _run_ctc_gpu(self, data, data_lengths,
-                     flat_labels, label_lengths,
-                     alphabet_size, expected_loss,
-                     expected_gradients, expected_error=None):
-        self.assertEquals(data.shape, expected_gradients.shape)
-        data_t = tf.constant(data, dtype=tf.float32)
-        data_lengths_t = tf.constant(data_lengths, dtype=tf.int32)
-        flat_labels_t = tf.constant(flat_labels, dtype=tf.int32)
-        label_lengths_t = tf.constant(label_lengths, dtype=tf.int32)
-        loss = ctc(data_t, data_lengths=data_lengths_t,
-                   flat_labels=flat_labels_t,
-                   label_lengths=label_lengths_t,
-                   alphabet_size=alphabet_size)
-        grad = tf.gradients(loss, [data_t])[0]
-        self.assertShapeEqual(expected_loss, loss)
-        self.assertShapeEqual(expected_gradients, grad)
-        log_dev_placement = True
-        tfconfig = tf.ConfigProto(log_device_placement=log_dev_placement,
-                                  allow_soft_placement=False)
-        with self.test_session(use_gpu=True, force_gpu=True, config=tfconfig) as sess:
-            if expected_error is None:
-                (tf_loss, tf_grad) = sess.run([loss, grad])
-                self.assertAllClose(tf_loss, expected_loss, atol=1e-6)
-                self.assertAllClose(tf_grad, expected_gradients, atol=1e-6)
-            else:
-                with self.assertRaisesOpError(expected_error):
-                    sess.run([loss, grad])
+                    sess.run([costs, grad])
+
+    def _test_basic(self, use_gpu):
+        # Softmax activations for the following inputs:
+        activations = np.array([
+            [0.1, 0.6, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.6, 0.1, 0.1]
+        ], dtype=np.float32)
+
+        alphabet_size = 5
+        # dimensions should be t, n, p: (t timesteps, n minibatches,
+        # p prob of each alphabet). This is one instance, so expand
+        # dimensions in the middle
+        activations = np.expand_dims(activations, 1)
+        labels = np.asarray([1, 2], dtype=np.int32)
+        expected_costs = np.asarray([2.46286], dtype=np.float32)
+        gradients = np.asarray([
+            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
+            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
+        ], dtype=np.float32)
+        expected_gradients = np.expand_dims(gradients, 1)
+        label_lengths = np.asarray([2], dtype=np.int32)
+        input_lengths = np.asarray([2], dtype=np.int32)
+
+        self._run_ctc(activations=activations,
+                      input_lengths=input_lengths,
+                      flat_labels=labels, label_lengths=label_lengths,
+                      expected_costs=expected_costs,
+                      expected_gradients=expected_gradients,
+                      use_gpu=use_gpu)
 
     def test_basic_cpu(self):
-        # Softmax activations for the following inputs:
-        activations = np.array([
-            [0.1, 0.6, 0.1, 0.1, 0.1],
-            [0.1, 0.1, 0.6, 0.1, 0.1]
-        ], dtype=np.float32)
-
-        alphabet_size = 5
-        # dimensions should be t, n, p: (t timesteps, n minibatches,
-        # p prob of each alphabet). This is one instance, so expand
-        # dimensions in the middle
-        data = np.expand_dims(activations, 1)
-        labels = np.asarray([1, 2], dtype=np.int32)
-        expected_loss = np.asarray([2.46286], dtype=np.float32)
-        gradients = np.asarray([
-            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
-            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
-        ], dtype=np.float32)
-        expected_gradients = np.expand_dims(gradients, 1)
-        label_lengths = np.asarray([2], dtype=np.int32)
-        data_lengths = np.asarray([2], dtype=np.int32)
-
-        self._run_ctc_cpu(data, data_lengths=data_lengths,
-                          flat_labels=labels, label_lengths=label_lengths,
-                          alphabet_size=alphabet_size,
-                          expected_loss=expected_loss,
-                          expected_gradients=expected_gradients)
+        self._test_basic(use_gpu=False)
 
     def test_basic_gpu(self):
-        # Softmax activations for the following inputs:
+        self._test_basic(use_gpu=True)
+
+    def _test_multiple_batches(self, use_gpu):
         activations = np.array([
             [0.1, 0.6, 0.1, 0.1, 0.1],
             [0.1, 0.1, 0.6, 0.1, 0.1]
@@ -101,36 +89,10 @@ class WarpCTCTest(tf.test.TestCase):
         # dimensions should be t, n, p: (t timesteps, n minibatches,
         # p prob of each alphabet). This is one instance, so expand
         # dimensions in the middle
-        data = np.expand_dims(activations, 1)
-        labels = np.asarray([1, 2], dtype=np.int32)
-        expected_loss = np.asarray([2.46286], dtype=np.float32)
-        gradients = np.asarray([
-            [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
-            [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
-        ], dtype=np.float32)
-        expected_gradients = np.expand_dims(gradients, 1)
-        label_lengths = np.asarray([2], dtype=np.int32)
-        data_lengths = np.asarray([2], dtype=np.int32)
-        self._run_ctc_gpu(data, data_lengths=data_lengths,
-                          flat_labels=labels, label_lengths=label_lengths,
-                          alphabet_size=alphabet_size,
-                          expected_loss=expected_loss,
-                          expected_gradients=expected_gradients)
-
-    def test_multiple_batches(self):
-        activations = np.array([
-            [0.1, 0.6, 0.1, 0.1, 0.1],
-            [0.1, 0.1, 0.6, 0.1, 0.1]
-        ], dtype=np.float32)
-
-        alphabet_size = 5
-        # dimensions should be t, n, p: (t timesteps, n minibatches,
-        # p prob of each alphabet). This is one instance, so expand
-        # dimensions in the middle
-        _data = np.expand_dims(activations, 1)
-        data = np.concatenate([_data, _data[...]], axis=1)
+        _activations = np.expand_dims(activations, 1)
+        activations = np.concatenate([_activations, _activations[...]], axis=1)
         labels = np.asarray([1, 2, 1, 2], dtype=np.int32)
-        expected_loss = np.asarray([2.46286, 2.46286], dtype=np.float32)
+        expected_costs = np.asarray([2.46286, 2.46286], dtype=np.float32)
         gradients = np.asarray([
             [0.177031, -0.708125, 0.177031, 0.177031, 0.177031],
             [0.177031, 0.177031, -0.708125, 0.177031, 0.177031]
@@ -140,14 +102,20 @@ class WarpCTCTest(tf.test.TestCase):
             [_expected_gradients, _expected_gradients[...]], axis=1)
 
         label_lengths = np.asarray([2, 2], dtype=np.int32)
-        data_lengths = np.asarray([2, 2], dtype=np.int32)
+        input_lengths = np.asarray([2, 2], dtype=np.int32)
 
-        self._run_ctc_cpu(data, data_lengths=data_lengths,
-                          flat_labels=labels, label_lengths=label_lengths,
-                          alphabet_size=alphabet_size,
-                          expected_loss=expected_loss,
-                          expected_gradients=expected_gradients)
+        self._run_ctc(activations=activations,
+                      input_lengths=input_lengths,
+                      flat_labels=labels, label_lengths=label_lengths,
+                      expected_costs=expected_costs,
+                      expected_gradients=expected_gradients,
+                      use_gpu=use_gpu)
 
+    def test_multiple_batches_cpu(self):
+        self._test_multiple_batches(use_gpu=False)
+
+    def test_multiple_batches_gpu(self):
+        self._test_multiple_batches(use_gpu=True)
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_binding/tests/test_warpctc_op.py
+++ b/tensorflow_binding/tests/test_warpctc_op.py
@@ -1,6 +1,11 @@
 import tensorflow as tf
 import numpy as np
 from warpctc_tensorflow import ctc
+from tensorflow.python.client import device_lib
+
+def is_gpu_available():
+    """Returns whether TensorFlow can access a GPU."""
+    return any(x.device_type == 'GPU' for x in device_lib.list_local_devices())
 
 class WarpCTCTest(tf.test.TestCase):
 
@@ -78,7 +83,10 @@ class WarpCTCTest(tf.test.TestCase):
         self._test_basic(use_gpu=False)
 
     def test_basic_gpu(self):
-        self._test_basic(use_gpu=True)
+        if (is_gpu_available()):
+            self._test_basic(use_gpu=True)
+        else:
+            print("Skipping GPU test, no gpus available")
 
     def _test_multiple_batches(self, use_gpu):
         activations = np.array([
@@ -116,7 +124,10 @@ class WarpCTCTest(tf.test.TestCase):
         self._test_multiple_batches(use_gpu=False)
 
     def test_multiple_batches_gpu(self):
-        self._test_multiple_batches(use_gpu=True)
+        if (is_gpu_available()):
+            self._test_multiple_batches(use_gpu=True)
+        else:
+            print("Skipping GPU test, no gpus available")
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_binding/tests/test_warpctc_op.py
+++ b/tensorflow_binding/tests/test_warpctc_op.py
@@ -13,9 +13,10 @@ class WarpCTCTest(tf.test.TestCase):
         input_lengths_t = tf.constant(input_lengths)
         flat_labels_t = tf.constant(flat_labels)
         label_lengths_t = tf.constant(label_lengths)
-        costs = ctc(activations_t, input_lengths=input_lengths_t,
+        costs = ctc(activations=activations_t,
                     flat_labels=flat_labels_t,
-                    label_lengths=label_lengths_t)
+                    label_lengths=label_lengths_t,
+                    input_lengths=input_lengths_t)
 
         grad = tf.gradients(costs, [activations_t])[0]
 

--- a/tensorflow_binding/warpctc_tensorflow/__init__.py
+++ b/tensorflow_binding/warpctc_tensorflow/__init__.py
@@ -1,0 +1,7 @@
+#import warpctc_tensorflow.kernels
+
+import imp
+import tensorflow as tf
+
+lib_file = imp.find_module('kernels', __path__)[1]
+tf.load_op_library(lib_file)

--- a/tensorflow_binding/warpctc_tensorflow/__init__.py
+++ b/tensorflow_binding/warpctc_tensorflow/__init__.py
@@ -2,6 +2,50 @@
 
 import imp
 import tensorflow as tf
+from tensorflow.python.framework import ops
+from tensorflow.python.ops.nn_grad import _BroadcastMul
 
 lib_file = imp.find_module('kernels', __path__)[1]
-tf.load_op_library(lib_file)
+_warpctc = tf.load_op_library(lib_file)
+
+def ctc(data, data_lengths, flat_labels, label_lengths, alphabet_size):
+    '''
+    compute_ctc_loss(const float* const activations,
+                             float* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             float *costs,
+                             void *workspace,
+                             ctcComputeInfo info);
+    We assume a fixed
+    memory layout for this 3 dimensional tensor, which has dimension
+    (t, n, p), where t is the time index, n is the minibatch index,
+    and p indexes over probabilities of each symbol in the alphabet.
+    The memory layout is (t, n, p) in C order (slowest to fastest changing
+    index, aka row-major), or (p, n, t) in Fortran order (fastest to slowest
+    changing index, aka column-major). We also assume strides are equal to
+    dimensions - there is no padding between dimensions.
+    More precisely, element (t, n, p), for a problem with mini_batch examples
+    in the mini batch, and alphabet_size symbols in the alphabet, is located at
+    activations[(t * mini_batch + n) * alphabet_size + p]
+    '''
+    loss, _ = _warpctc.warp_ctc(data, data_lengths, flat_labels,
+                                label_lengths, alphabet_size)
+    return loss
+
+
+@ops.RegisterGradient("WarpCTC")
+def _CTCLossGrad(op, grad_loss, _):
+    grad = op.outputs[1]
+    return [_BroadcastMul(grad_loss, grad), None, None, None]
+
+
+@ops.RegisterShape("WarpCTC")
+def _CTCLossShape(op):
+    inputs_shape = op.inputs[0].get_shape().with_rank(3)
+    batch_size = inputs_shape[1]
+    return [batch_size, inputs_shape]
+

--- a/tensorflow_binding/warpctc_tensorflow/__init__.py
+++ b/tensorflow_binding/warpctc_tensorflow/__init__.py
@@ -8,7 +8,7 @@ from tensorflow.python.ops.nn_grad import _BroadcastMul
 lib_file = imp.find_module('kernels', __path__)[1]
 _warpctc = tf.load_op_library(lib_file)
 
-def ctc(data, data_lengths, flat_labels, label_lengths, alphabet_size):
+def ctc(activations, input_lengths, flat_labels, label_lengths):
     '''
     compute_ctc_loss(const float* const activations,
                              float* gradients,
@@ -32,8 +32,7 @@ def ctc(data, data_lengths, flat_labels, label_lengths, alphabet_size):
     in the mini batch, and alphabet_size symbols in the alphabet, is located at
     activations[(t * mini_batch + n) * alphabet_size + p]
     '''
-    loss, _ = _warpctc.warp_ctc(data, data_lengths, flat_labels,
-                                label_lengths, alphabet_size)
+    loss, _ = _warpctc.warp_ctc(activations, flat_labels, label_lengths, input_lengths)
     return loss
 
 

--- a/tensorflow_binding/warpctc_tensorflow/__init__.py
+++ b/tensorflow_binding/warpctc_tensorflow/__init__.py
@@ -1,5 +1,3 @@
-#import warpctc_tensorflow.kernels
-
 import imp
 import tensorflow as tf
 from tensorflow.python.framework import ops

--- a/tensorflow_binding/warpctc_tensorflow/__init__.py
+++ b/tensorflow_binding/warpctc_tensorflow/__init__.py
@@ -8,7 +8,8 @@ from tensorflow.python.ops.nn_grad import _BroadcastMul
 lib_file = imp.find_module('kernels', __path__)[1]
 _warpctc = tf.load_op_library(lib_file)
 
-def ctc(activations, flat_labels, label_lengths, input_lengths):
+def ctc(activations, flat_labels, label_lengths, input_lengths,
+        blank_label=0):
     '''Computes the CTC loss between a sequence of activations and a
     ground truth labeling.
 
@@ -28,6 +29,9 @@ def ctc(activations, flat_labels, label_lengths, input_lengths):
         input_lengths: A 1-D Tensor of ints, the number of time steps
                        for each sequence in the minibatch.
 
+        blank_label: int, the label value/index that the CTC
+                     calculation should use as the blank label
+
     Returns:
         1-D float Tensor, the cost of each example in the minibatch
         (as negative log probabilities).
@@ -37,7 +41,8 @@ def ctc(activations, flat_labels, label_lengths, input_lengths):
     * The label reserved for the blank symbol should be label 0.
 
     '''
-    loss, _ = _warpctc.warp_ctc(activations, flat_labels, label_lengths, input_lengths)
+    loss, _ = _warpctc.warp_ctc(activations, flat_labels, label_lengths,
+                                input_lengths, blank_label)
     return loss
 
 

--- a/tests/test_cpu.cpp
+++ b/tests/test_cpu.cpp
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <cstring>
 #include <random>
 #include <tuple>
 #include <vector>
@@ -35,8 +34,7 @@ bool small_test() {
 
     float score;
 
-    ctcOptions options;
-    memset(&options, 0, sizeof(options));
+    ctcOptions options{};
     options.loc = CTC_CPU;
     options.num_threads = 1;
 
@@ -136,8 +134,7 @@ bool options_test() {
 
     std::vector<float> scores(2);
 
-    ctcOptions options;
-    memset(&options, 0, sizeof(options));
+    ctcOptions options{};
     options.loc = CTC_CPU;
     options.num_threads = 1;
     options.blank_label = 5;
@@ -166,8 +163,8 @@ bool options_test() {
 
     bool result = true;
     for (int i = 0; i < grads.size(); i++) {
-        double lb = expected_grads[i] - eps;
-        double ub = expected_grads[i] + eps;
+        const double lb = expected_grads[i] - eps;
+        const double ub = expected_grads[i] + eps;
         if (!(grads[i] > lb && grads[i] < ub)) {
             std::cerr << "grad mismatch in options_test"
                       << " expected grad: " << expected_grads[i]
@@ -179,8 +176,8 @@ bool options_test() {
     }
 
     for (int i = 0; i < 2; i++) {
-        double lb = expected_scores[i] - eps;
-        double ub = expected_scores[i] + eps;
+        const double lb = expected_scores[i] - eps;
+        const double ub = expected_scores[i] + eps;
         if (!(scores[i] > lb && scores[i] < ub)) {
             std::cerr << "score mismatch in options_test"
                       << " expected score: " << expected_scores[i]
@@ -215,8 +212,7 @@ bool inf_test() {
 
     float cost;
 
-    ctcOptions options;
-    memset(&options, 0, sizeof(options));
+    ctcOptions options{};
     options.loc = CTC_CPU;
     options.num_threads = 1;
 
@@ -269,8 +265,7 @@ float grad_check(int T, int alphabet_size,
 
     std::vector<float> grads(acts.size());
 
-    ctcOptions options;
-    memset(&options, 0, sizeof(options));
+    ctcOptions options{};
     options.loc = CTC_CPU;
     options.num_threads = 1;
 

--- a/tests/test_cpu.cpp
+++ b/tests/test_cpu.cpp
@@ -366,7 +366,7 @@ bool run_tests() {
 }
 
 int main(void) {
-    if (get_warpctc_version() != 1) {
+    if (get_warpctc_version() != 2) {
         std::cerr << "Invalid WarpCTC version." << std::endl;
         return 1;
     }

--- a/tests/test_gpu.cu
+++ b/tests/test_gpu.cu
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstring>
 #include <random>
 #include <tuple>
 #include <vector>
@@ -30,7 +31,7 @@ bool small_test() {
                    "cudaStreamCreate");
 
     float *activations_gpu;
-    throw_on_error(cudaMalloc(&activations_gpu, 
+    throw_on_error(cudaMalloc(&activations_gpu,
                    activations.size() * sizeof(float)),
                    "cudaMalloc");
     throw_on_error(cudaMemcpyAsync(activations_gpu, activations.data(),
@@ -46,13 +47,18 @@ bool small_test() {
 
     float score;
 
-    ctcComputeInfo info;
-    info.loc = CTC_GPU;
-    info.stream = stream;
+    float *grads_gpu;
+    throw_on_error(cudaMalloc(&grads_gpu, (alphabet_size * T) * sizeof(float)),
+                   "cudaMalloc");
+
+    ctcOptions options;
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.stream = stream;
 
     size_t gpu_alloc_bytes;
     throw_on_error(get_workspace_size(label_lengths.data(), lengths.data(),
-                                      alphabet_size, lengths.size(), info,
+                                      alphabet_size, lengths.size(), options,
                                       &gpu_alloc_bytes),
                    "Error: get_workspace_size in small_test");
 
@@ -60,14 +66,14 @@ bool small_test() {
     throw_on_error(cudaMalloc(&ctc_gpu_workspace, gpu_alloc_bytes),
                    "cudaMalloc");
 
-    throw_on_error(compute_ctc_loss(activations_gpu, NULL,
+    throw_on_error(compute_ctc_loss(activations_gpu, grads_gpu,
                                     labels.data(), label_lengths.data(),
                                     lengths.data(),
                                     alphabet_size,
                                     lengths.size(),
                                     &score,
                                     ctc_gpu_workspace,
-                                    info),
+                                    options),
                    "Error: compute_ctc_loss in small_test");
 
     score = std::exp(-score);
@@ -75,6 +81,16 @@ bool small_test() {
 
     const float lb = expected_score - eps;
     const float ub = expected_score + eps;
+
+    std::vector<float> grads(alphabet_size * T);
+    throw_on_error(cudaMemcpyAsync(grads.data(), grads_gpu,
+                                   grads.size() * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream),
+                   "cudaMemcpyAsync");
+    throw_on_error(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+    // for (int i = 0; i < alphabet_size * T; ++i)
+    //     status &= !std::isnan(grads[i]);
 
     throw_on_error(cudaFree(activations_gpu),
                    "cudaFree");
@@ -85,6 +101,159 @@ bool small_test() {
 
     return (score > lb && score < ub);
 }
+
+int offset(int t, int n, int a) {
+    constexpr int minibatch = 2;
+    constexpr int alphabet_size = 6;
+    return (t * minibatch + n) * alphabet_size + a;
+}
+
+bool options_test() {
+    const int alphabet_size = 6;
+    const int T = 5;
+    const int minibatch = 2;
+
+    std::vector<float> activations =
+            {0.633766, 0.221185, 0.0917319, 0.0129757, 0.0142857, 0.0260553,
+             0.30176, 0.28562, 0.0831517, 0.0862751, 0.0816851, 0.161508,
+
+             0.111121, 0.588392, 0.278779, 0.0055756, 0.00569609, 0.010436,
+             0.24082, 0.397533, 0.0557226, 0.0546814, 0.0557528, 0.19549,
+
+             0.0357786, 0.633813, 0.321418, 0.00249248, 0.00272882, 0.0037688,
+             0.230246, 0.450868, 0.0389607, 0.038309, 0.0391602, 0.202456,
+
+             0.0663296, 0.643849, 0.280111, 0.00283995, 0.0035545, 0.00331533,
+             0.280884, 0.429522, 0.0326593, 0.0339046, 0.0326856, 0.190345,
+
+             0.458235, 0.396634, 0.123377, 0.00648837, 0.00903441, 0.00623107,
+             0.423286, 0.315517, 0.0338439, 0.0393744, 0.0339315, 0.154046};
+
+    std::vector<float> expected_grads = // from tensorflow
+            {-0.366234, 0.221185, 0.0917319, 0.0129757, 0.0142857, 0.0260553,
+             -0.69824, 0.28562, 0.0831517, 0.0862751, 0.0816851, 0.161508,
+
+             0.111121, -0.411608, 0.278779, 0.0055756, 0.00569609, 0.010436,
+             0.24082, -0.602467, 0.0557226, 0.0546814, 0.0557528, 0.19549,
+
+             0.0357786, 0.633813, -0.678582, 0.00249248, 0.00272882, 0.0037688,
+             0.230246, 0.450868, 0.0389607, 0.038309, 0.0391602, -0.797544,
+
+             0.0663296, -0.356151, 0.280111, 0.00283995, 0.0035545, 0.00331533,
+             0.280884, -0.570478, 0.0326593, 0.0339046, 0.0326856, 0.190345,
+
+             -0.541765, 0.396634, 0.123377, 0.00648837, 0.00903441, 0.00623107,
+             -0.576714, 0.315517, 0.0338439, 0.0393744, 0.0339315, 0.154046};
+
+    // Calculate the expected scores analytically
+    auto& a = activations;
+    double expected_score[2];
+    expected_score[0] =
+            -std::log(a[offset(0, 0, 0)] * a[offset(1, 0, 1)] * a[offset(2, 0, 2)]
+                     * a[offset(3, 0, 1)] * a[offset(4, 0, 0)]);
+    expected_score[1] = 5.42262; // from tensorflow
+
+    // now take the log to account for the softmax
+    for (auto& a : activations) {
+        a = std::log(a);
+    }
+
+    cudaStream_t stream;
+    throw_on_error(cudaStreamCreate(&stream),
+                   "cudaStreamCreate");
+
+    float *activations_gpu;
+    throw_on_error(cudaMalloc(&activations_gpu,
+                   activations.size() * sizeof(float)),
+                   "cudaMalloc");
+    throw_on_error(cudaMemcpyAsync(activations_gpu, activations.data(),
+                                   activations.size() * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream),
+                   "cudaMemcpyAsync");
+
+    std::vector<int> labels = {0, 1, 2, 1, 0,
+                               0, 1, 1, 0};
+
+    std::vector<int> label_lengths = {5, 4};
+
+    std::vector<int> lengths = {5, 5};
+
+    float score[2];
+
+    float *grads_gpu;
+    throw_on_error(cudaMalloc(&grads_gpu, (alphabet_size * T * minibatch) * sizeof(float)),
+                   "cudaMalloc");
+
+    ctcOptions options;
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.stream = stream;
+    options.blank_label = 5;
+
+    size_t gpu_alloc_bytes;
+    throw_on_error(get_workspace_size(label_lengths.data(), lengths.data(),
+                                      alphabet_size, lengths.size(), options,
+                                      &gpu_alloc_bytes),
+                   "Error: get_workspace_size in options_test");
+
+    char *ctc_gpu_workspace;
+    throw_on_error(cudaMalloc(&ctc_gpu_workspace, gpu_alloc_bytes),
+                   "cudaMalloc");
+
+    throw_on_error(compute_ctc_loss(activations_gpu, grads_gpu,
+                                    labels.data(), label_lengths.data(),
+                                    lengths.data(),
+                                    alphabet_size,
+                                    lengths.size(),
+                                    &score[0],
+                                    ctc_gpu_workspace,
+                                    options),
+                   "Error: compute_ctc_loss in options_test");
+
+    std::vector<float> grads(alphabet_size * T * minibatch);
+    throw_on_error(cudaMemcpyAsync(grads.data(), grads_gpu,
+                                   grads.size() * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream),
+                   "cudaMemcpyAsync");
+    throw_on_error(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+    throw_on_error(cudaFree(activations_gpu),
+                   "cudaFree");
+    throw_on_error(cudaFree(ctc_gpu_workspace),
+                   "cudaFree");
+    throw_on_error(cudaStreamDestroy(stream),
+                   "cudaStreamDestroy");
+
+    const double eps = 1e-4;
+
+    bool result = true;
+    for (int i = 0; i < grads.size(); i++) {
+        double lb = expected_grads[i] - eps;
+        double ub = expected_grads[i] + eps;
+        if (!(grads[i] > lb && grads[i] < ub)) {
+            std::cerr << "grad mismatch in options_test"
+                      << " expected grad: " << expected_grads[i]
+                      << " calculated score: " << grads[i]
+                      << " !(" << lb << " < " << grads[i]
+                      << " < " << ub << ")" << std::endl;
+            result = false;
+        }
+    }
+
+    for (int i = 0; i < 2; i++) {
+        double lb = expected_score[i] - eps;
+        double ub = expected_score[i] + eps;
+
+        if (!(score[i] > lb && score[i] < ub)) {
+            std::cerr << "score mismatch in options_test"
+                      << " expected score: " << expected_score[i]
+                      << " calculated score: " << score[i] << std::endl;
+            result = false;
+        }
+    }
+    return result;
+}
+
 
 bool inf_test() {
     const int alphabet_size = 15;
@@ -108,7 +277,7 @@ bool inf_test() {
     float *acts_gpu;
     throw_on_error(cudaMalloc(&acts_gpu, acts.size() * sizeof(float)),
                    "cudaMalloc");
-    throw_on_error(cudaMemcpyAsync(acts_gpu, acts.data(), 
+    throw_on_error(cudaMemcpyAsync(acts_gpu, acts.data(),
                                    acts.size() * sizeof(float),
                                    cudaMemcpyHostToDevice, stream),
                    "cudaMemcpyAsync");
@@ -122,13 +291,14 @@ bool inf_test() {
 
     float cost;
 
-    ctcComputeInfo info;
-    info.loc = CTC_GPU;
-    info.stream = stream;
+    ctcOptions options;
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.stream = stream;
 
     size_t gpu_alloc_bytes;
     throw_on_error(get_workspace_size(label_lengths.data(), lengths.data(),
-                                      alphabet_size, lengths.size(), info,
+                                      alphabet_size, lengths.size(), options,
                                       &gpu_alloc_bytes),
                    "Error: get_workspace_size in inf_test");
 
@@ -143,13 +313,13 @@ bool inf_test() {
                                     lengths.size(),
                                     &cost,
                                     ctc_gpu_workspace,
-                                    info),
+                                    options),
                    "Error: compute_ctc_loss in inf_test");
 
     bool status = std::isinf(cost);
 
     std::vector<float> grads(alphabet_size * T);
-    throw_on_error(cudaMemcpyAsync(grads.data(), grads_gpu, 
+    throw_on_error(cudaMemcpyAsync(grads.data(), grads_gpu,
                                    grads.size() * sizeof(float),
                                    cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync");
@@ -200,16 +370,17 @@ float grad_check(int T, int alphabet_size,
     throw_on_error(cudaMalloc(&grads_gpu, acts.size() * sizeof(float)),
                    "cudaMalloc");
 
-    ctcComputeInfo info;
-    info.loc = CTC_GPU;
-    info.stream = stream;
+    ctcOptions options;
+    memset(&options, 0, sizeof(options));
+    options.loc = CTC_GPU;
+    options.stream = stream;
 
     size_t gpu_alloc_bytes;
     throw_on_error(get_workspace_size(label_lengths.data(),
                                       lengths.data(),
                                       alphabet_size,
                                       lengths.size(),
-                                      info,
+                                      options,
                                       &gpu_alloc_bytes),
                    "Error: get_workspace_size in grad_check");
 
@@ -218,18 +389,18 @@ float grad_check(int T, int alphabet_size,
                    "cudaMalloc");
 
     throw_on_error(compute_ctc_loss(acts_gpu, grads_gpu,
-                                    flat_labels.data(), 
+                                    flat_labels.data(),
                                     label_lengths.data(),
                                     lengths.data(),
                                     alphabet_size,
                                     minibatch,
                                     costs.data(),
                                     ctc_gpu_workspace,
-                                    info),
+                                    options),
                    "Error: compute_ctc_loss (0) in grad_check");
 
     std::vector<float> grads(acts.size());
-    throw_on_error(cudaMemcpyAsync(grads.data(), 
+    throw_on_error(cudaMemcpyAsync(grads.data(),
                                    grads_gpu, grads.size() * sizeof(float),
                                    cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync");
@@ -240,7 +411,7 @@ float grad_check(int T, int alphabet_size,
     for (int i = 0; i < T * alphabet_size * minibatch; ++i) {
         acts[i] += epsilon;
 
-        throw_on_error(cudaMemcpyAsync(acts_gpu, acts.data(), 
+        throw_on_error(cudaMemcpyAsync(acts_gpu, acts.data(),
                                        acts.size() * sizeof(float),
                                        cudaMemcpyHostToDevice, stream),
                        "cudaMemcpyAsync");
@@ -249,14 +420,14 @@ float grad_check(int T, int alphabet_size,
         std::vector<float> costsP2(minibatch);
 
         throw_on_error(compute_ctc_loss(acts_gpu, NULL,
-                                        flat_labels.data(), 
+                                        flat_labels.data(),
                                         label_lengths.data(),
                                         lengths.data(),
                                         alphabet_size,
                                         minibatch,
                                         costsP1.data(),
                                         ctc_gpu_workspace,
-                                        info),
+                                        options),
                        "Error: compute_ctc_loss (1) in grad_check");
 
         acts[i] -= 2 * epsilon;
@@ -273,7 +444,7 @@ float grad_check(int T, int alphabet_size,
                                         minibatch,
                                         costsP2.data(),
                                         ctc_gpu_workspace,
-                                        info),
+                                        options),
                        "Error: compute_ctc_loss (2) in grad_check");
 
         float costP1 = std::accumulate(costsP1.begin(), costsP1.end(), 0.);
@@ -330,9 +501,10 @@ int main(void) {
     throw_on_error(cudaSetDevice(0), "cudaSetDevice");
 
     bool status = true;
-    status &= small_test();
-    status &= inf_test();
-    status &= run_tests();
+    //status &= small_test();
+    status &= options_test();
+    //status &= inf_test();
+    //status &= run_tests();
 
     if (status)
         std::cout << "Tests pass" << std::endl;

--- a/tests/test_gpu.cu
+++ b/tests/test_gpu.cu
@@ -478,7 +478,7 @@ bool run_tests() {
 }
 
 int main(void) {
-    if (get_warpctc_version() != 1) {
+    if (get_warpctc_version() != 2) {
         std::cerr << "Invalid WarpCTC version." << std::endl;
         return 1;
     }


### PR DESCRIPTION
Includes a breaking change to the interface.  Instead of ctcComputeInfo there is ctcOptions which allows the caller to specify which label is the reserved blank label.  This was needed because TensorFlow's CTCLoss op has the blank label as the highest value, not zero.

Thus, the current HEAD should be tagged (probably "v1.0"?) and a branch created ("v1"?) from there before this is merged.
