### PR TITLE
Add a flag to use the old C++ ABI when compiled with newer GCC.

### DIFF
--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -59,6 +59,8 @@ include_dirs = tf_includes + warp_ctc_includes
 extra_compile_args = ['-std=c++11', '-fPIC']
 # current tensorflow code triggers return type errors, silence those for now
 extra_compile_args += ['-Wno-return-type']
+# The following is neccessary to compile with G++5 as Tensorflow uses the old ABI.
+extra_compile_args += [ '-D_GLIBCXX_USE_CXX11_ABI=0']
 
 if (enable_gpu):
     extra_compile_args += ['-DWARPCTC_ENABLE_GPU']


### PR DESCRIPTION
This adds a compile flag which specifies that newer GCC version should use the old ABI when compiling the Tensorflow extension.