### PR TITLE
Add interface supporting double type

### DIFF
--- a/include/ctc.h
+++ b/include/ctc.h
@@ -111,6 +111,16 @@ API_REFERENCE ctcStatus_t compute_ctc_loss(const float* const activations,
                              float *costs,
                              void *workspace,
                              ctcOptions options);
+API_REFERENCE ctcStatus_t compute_ctc_loss_double(const double* const activations,
+                             double* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             double *costs,
+                             void *workspace,
+                             ctcOptions options);
 
 
 /** For a given set of labels and minibatch size return the required workspace
@@ -131,6 +141,12 @@ API_REFERENCE ctcStatus_t compute_ctc_loss(const float* const activations,
  *  \return Status information
  **/
 API_REFERENCE ctcStatus_t get_workspace_size(const int* const label_lengths,
+                               const int* const input_lengths,
+                               int alphabet_size, int minibatch,
+                               ctcOptions info,
+                               size_t* size_bytes);
+
+API_REFERENCE ctcStatus_t  get_workspace_size_double(const int* const label_lengths,
                                const int* const input_lengths,
                                int alphabet_size, int minibatch,
                                ctcOptions info,

--- a/include/detail/gpu_ctc.h
+++ b/include/detail/gpu_ctc.h
@@ -367,7 +367,7 @@ GpuCTC<ProbT>::compute_probs(const ProbT* const activations) {
 
     // Numerically stable SM
     ctcStatus_t ctc_status =
-        reduce_max(probs_, denoms_, out_dim_,
+        reduce_max<ProbT>(probs_, denoms_, out_dim_,
                    activation_cols_, 1, stream_);
     if (ctc_status != CTC_STATUS_SUCCESS)
         return ctc_status;
@@ -385,7 +385,7 @@ GpuCTC<ProbT>::compute_probs(const ProbT* const activations) {
 
     // Reduce along columns to calculate denominator
     ctc_status =
-        reduce_exp(probs_, denoms_, out_dim_,
+        reduce_exp<ProbT>(probs_, denoms_, out_dim_,
                    activation_cols_, 1, stream_);
     if (ctc_status != CTC_STATUS_SUCCESS)
         return ctc_status;

--- a/include/detail/reduce.h
+++ b/include/detail/reduce.h
@@ -1,5 +1,8 @@
 #pragma once
 
-ctcStatus_t reduce_negate(const float* input, float* output, int rows, int cols, bool axis, cudaStream_t stream);
-ctcStatus_t reduce_exp(const float* input, float* output, int rows, int cols, bool axis, cudaStream_t stream);
-ctcStatus_t reduce_max(const float* input, float* output, int rows, int cols, bool axis, cudaStream_t stream);
+template <typename T>
+ctcStatus_t reduce_negate(const T* input, T* output, int rows, int cols, bool axis, cudaStream_t stream);
+template <typename T>
+ctcStatus_t reduce_exp(const T* input, T* output, int rows, int cols, bool axis, cudaStream_t stream);
+template <typename T>
+ctcStatus_t reduce_max(const T* input, T* output, int rows, int cols, bool axis, cudaStream_t stream);

--- a/src/ctc_entrypoint.cpp
+++ b/src/ctc_entrypoint.cpp
@@ -1,6 +1,7 @@
-#include <cstddef>
+#include <stdio.h>
 #include <iostream>
 #include <algorithm>
+#include <cstdio>
 
 #include <ctc.h>
 
@@ -71,6 +72,59 @@ ctcStatus_t compute_ctc_loss(const float* const activations,
     } else if (options.loc == CTC_GPU) {
 #ifdef __CUDACC__
         GpuCTC<float> ctc(alphabet_size, minibatch, workspace, options.stream,
+                          options.blank_label);
+
+        if (gradients != NULL)
+            return ctc.cost_and_grad(activations, gradients, costs,
+                                     flat_labels, label_lengths,
+                                     input_lengths);
+        else
+            return ctc.score_forward(activations, costs, flat_labels,
+                                     label_lengths, input_lengths);
+#else
+        std::cerr << "GPU execution requested, but not compiled with GPU support" << std::endl;
+        return CTC_STATUS_EXECUTION_FAILED;
+#endif
+    } else {
+        return CTC_STATUS_INVALID_VALUE;
+    }
+}
+
+ctcStatus_t compute_ctc_loss_double(const double* const activations,
+                             double* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             double *costs,
+                             void *workspace,
+                             ctcOptions options) {
+    if (activations == nullptr ||
+        flat_labels == nullptr ||
+        label_lengths == nullptr ||
+        input_lengths == nullptr ||
+        costs == nullptr ||
+        workspace == nullptr ||
+        alphabet_size <= 0 ||
+        minibatch <= 0)
+        return CTC_STATUS_INVALID_VALUE;
+
+    if (options.loc == CTC_CPU) {
+        CpuCTC<double> ctc(alphabet_size, minibatch, workspace, options.num_threads,
+                          options.blank_label);
+
+        if (gradients != NULL)
+            return ctc.cost_and_grad(activations, gradients,
+                                     costs,
+                                     flat_labels, label_lengths,
+                                     input_lengths);
+        else
+            return ctc.score_forward(activations, costs, flat_labels,
+                                     label_lengths, input_lengths);
+    } else if (options.loc == CTC_GPU) {
+#ifdef __CUDACC__
+        GpuCTC<double> ctc(alphabet_size, minibatch, workspace, options.stream,
                           options.blank_label);
 
         if (gradients != NULL)
@@ -167,6 +221,88 @@ ctcStatus_t get_workspace_size(const int* const label_lengths,
 
         //probs
         *size_bytes += sizeof(float) * alphabet_size * maxT * minibatch;
+    }
+
+    return CTC_STATUS_SUCCESS;
+}
+
+ctcStatus_t get_workspace_size_double(const int* const label_lengths,
+                               const int* const input_lengths,
+                               int alphabet_size, int minibatch,
+                               ctcOptions options,
+                               size_t* size_bytes)
+{
+    if (label_lengths == nullptr ||
+        input_lengths == nullptr ||
+        size_bytes == nullptr ||
+        alphabet_size <= 0 ||
+        minibatch <= 0)
+        return CTC_STATUS_INVALID_VALUE;
+
+    // This is the max of all S and T for all examples in the minibatch.
+    int maxL = *std::max_element(label_lengths, label_lengths + minibatch);
+    int maxT = *std::max_element(input_lengths, input_lengths + minibatch);
+
+    const int S = 2 * maxL + 1;
+
+    *size_bytes = 0;
+
+    if (options.loc == CTC_GPU) {
+        // GPU storage
+        //nll_forward, nll_backward
+        *size_bytes += 2 * sizeof(double) * minibatch;
+
+        //repeats
+        *size_bytes += sizeof(double) * minibatch;
+
+        //label offsets
+        *size_bytes += sizeof(double) * minibatch;
+
+        //utt_length
+        *size_bytes += sizeof(double) * minibatch;
+
+        //label lengths
+        *size_bytes += sizeof(double) * minibatch;
+
+        //labels without blanks - overallocate for now
+        *size_bytes += sizeof(double) * maxL * minibatch;
+
+        //labels with blanks
+        *size_bytes += sizeof(double) * S * minibatch;
+
+        //alphas
+        *size_bytes += sizeof(double) * S * maxT * minibatch;
+
+        //denoms
+        *size_bytes += sizeof(double) * maxT * minibatch;
+
+        //probs (since we will pass in activations)
+        *size_bytes += sizeof(double) * alphabet_size * maxT * minibatch;
+
+    } else {
+        //cpu can eventually replace all minibatch with
+        //max number of concurrent threads if memory is
+        //really tight
+
+        //per minibatch memory
+        size_t per_minibatch_bytes = 0;
+
+        //output
+        per_minibatch_bytes += sizeof(double) * alphabet_size ;
+
+        //alphas
+        per_minibatch_bytes += sizeof(double) * S * maxT;
+
+        //betas
+        per_minibatch_bytes += sizeof(double) * S;
+
+        //labels w/blanks, e_inc, s_inc
+        per_minibatch_bytes += 3 * sizeof(double) * S;
+
+        *size_bytes = per_minibatch_bytes * minibatch;
+
+        //probs
+        *size_bytes += sizeof(double) * alphabet_size * maxT * minibatch;
     }
 
     return CTC_STATUS_SUCCESS;

--- a/src/ctc_entrypoint.cpp
+++ b/src/ctc_entrypoint.cpp
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstddef>
 #include <iostream>
 #include <algorithm>
 #include <cstdio>
@@ -253,22 +253,22 @@ ctcStatus_t get_workspace_size_double(const int* const label_lengths,
         *size_bytes += 2 * sizeof(double) * minibatch;
 
         //repeats
-        *size_bytes += sizeof(double) * minibatch;
+        *size_bytes += sizeof(int) * minibatch;
 
         //label offsets
-        *size_bytes += sizeof(double) * minibatch;
+        *size_bytes += sizeof(int) * minibatch;
 
         //utt_length
-        *size_bytes += sizeof(double) * minibatch;
+        *size_bytes += sizeof(int) * minibatch;
 
         //label lengths
-        *size_bytes += sizeof(double) * minibatch;
+        *size_bytes += sizeof(int) * minibatch;
 
         //labels without blanks - overallocate for now
-        *size_bytes += sizeof(double) * maxL * minibatch;
+        *size_bytes += sizeof(int) * maxL * minibatch;
 
         //labels with blanks
-        *size_bytes += sizeof(double) * S * minibatch;
+        *size_bytes += sizeof(int) * S * minibatch;
 
         //alphas
         *size_bytes += sizeof(double) * S * maxT * minibatch;
@@ -297,7 +297,7 @@ ctcStatus_t get_workspace_size_double(const int* const label_lengths,
         per_minibatch_bytes += sizeof(double) * S;
 
         //labels w/blanks, e_inc, s_inc
-        per_minibatch_bytes += 3 * sizeof(double) * S;
+        per_minibatch_bytes += 3 * sizeof(int) * S;
 
         *size_bytes = per_minibatch_bytes * minibatch;
 

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -148,15 +148,23 @@ ctcStatus_t reduce(Iof f, Rof g, const T* input, T* output, int rows, int cols, 
 
     return CTC_STATUS_SUCCESS;
 }
-
-ctcStatus_t reduce_negate(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream) {
-    return reduce(ctc_helper::negate<float>(), ctc_helper::add<float>(), input, output, rows, cols, axis, stream);
+template<typename T>
+ctcStatus_t reduce_negate(const T *input, T *output, int rows, int cols, bool axis, cudaStream_t stream) {
+    return reduce(ctc_helper::negate<T>(), ctc_helper::add<T>(), input, output, rows, cols, axis, stream);
 }
+template ctcStatus_t reduce_negate<float>(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream);
+template ctcStatus_t reduce_negate<double>(const double *input, double *output, int rows, int cols, bool axis, cudaStream_t stream);
 
-ctcStatus_t reduce_exp(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream) {
-    return reduce(ctc_helper::exponential<float>(), ctc_helper::add<float>(), input, output, rows, cols, axis, stream);
+template<typename T>
+ctcStatus_t reduce_exp(const T *input, T *output, int rows, int cols, bool axis, cudaStream_t stream) {
+    return reduce(ctc_helper::exponential<T>(), ctc_helper::add<T>(), input, output, rows, cols, axis, stream);
 }
+template ctcStatus_t reduce_exp<float>(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream);
+template ctcStatus_t reduce_exp<double>(const double *input, double *output, int rows, int cols, bool axis, cudaStream_t stream);
 
-ctcStatus_t reduce_max(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream) {
-    return reduce(ctc_helper::identity<float>(), ctc_helper::maximum<float>(),input, output, rows, cols, axis, stream);
+template<typename T>
+ctcStatus_t reduce_max(const T *input, T *output, int rows, int cols, bool axis, cudaStream_t stream) {
+    return reduce(ctc_helper::identity<T>(), ctc_helper::maximum<T>(),input, output, rows, cols, axis, stream);
 }
+template ctcStatus_t reduce_max<float>(const float *input, float *output, int rows, int cols, bool axis, cudaStream_t stream);
+template ctcStatus_t reduce_max<double>(const double *input, double *output, int rows, int cols, bool axis, cudaStream_t stream);


### PR DESCRIPTION
1、add interface compute_ctc_loss_double to support double probabilities.
2、add interface get_workspace_size_double to support get workspace when probability is double.
3、add template for reduce to support compute_ctc_loss_double on gpu.