### PR TITLE
API improvement of use_softmax and zero_infinity

### DIFF
--- a/include/ctc.h
+++ b/include/ctc.h
@@ -70,6 +70,12 @@ struct ctcOptions {
 
     /// the label value/index that the CTC calculation should use as the blank label
     int blank_label;
+
+    /// indicate whether to apply softmax on the input first.
+    bool use_softmax = true;
+
+    /// indicate whether to zero infinite losses and the associated gradients.
+    bool zero_infinity = false;
 };
 
 /** Compute the connectionist temporal classification loss between 

--- a/src/ctc_entrypoint.cpp
+++ b/src/ctc_entrypoint.cpp
@@ -59,7 +59,7 @@ ctcStatus_t compute_ctc_loss(const float* const activations,
 
     if (options.loc == CTC_CPU) {
         CpuCTC<float> ctc(alphabet_size, minibatch, workspace, options.num_threads,
-                          options.blank_label);
+                          options.blank_label, options.use_softmax, options.zero_infinity);
 
         if (gradients != NULL)
             return ctc.cost_and_grad(activations, gradients,
@@ -72,7 +72,7 @@ ctcStatus_t compute_ctc_loss(const float* const activations,
     } else if (options.loc == CTC_GPU) {
 #if (defined(__HIPCC__) || defined(__CUDACC__))
         GpuCTC<float> ctc(alphabet_size, minibatch, workspace, options.stream,
-                          options.blank_label);
+                          options.blank_label, options.use_softmax, options.zero_infinity);
 
         if (gradients != NULL)
             return ctc.cost_and_grad(activations, gradients, costs,
@@ -112,7 +112,7 @@ ctcStatus_t compute_ctc_loss_double(const double* const activations,
 
     if (options.loc == CTC_CPU) {
         CpuCTC<double> ctc(alphabet_size, minibatch, workspace, options.num_threads,
-                          options.blank_label);
+                          options.blank_label, options.use_softmax, options.zero_infinity);
 
         if (gradients != NULL)
             return ctc.cost_and_grad(activations, gradients,
@@ -125,7 +125,7 @@ ctcStatus_t compute_ctc_loss_double(const double* const activations,
     } else if (options.loc == CTC_GPU) {
 #if (defined(__HIPCC__) || defined(__CUDACC__))
         GpuCTC<double> ctc(alphabet_size, minibatch, workspace, options.stream,
-                          options.blank_label);
+                          options.blank_label, options.use_softmax, options.zero_infinity);
 
         if (gradients != NULL)
             return ctc.cost_and_grad(activations, gradients, costs,


### PR DESCRIPTION
From a suggestion proposed by PaddlePaddle community, it is recommended to add  `use_softmax` and `zero_infinity` options to warpctc, comparing to the Pytorch API of `torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0, reduction='mean', zero_infinity=False)`.

I made an attempt to add this two options in this PR, and the logic is shown the following:

- `use_softmax`: The attribute of `log_probs` in Pytorch receives the output of logsoftmax operation. Therefore, it is suggested when the users want to use the output from logsoftmax operation as an input, we could omit the softmax operation in our code. The proposed improvement is when `use_softmax=False`, perform exponential operation on the input logits.

- `zero_infinity`: It is hoped to zero the infinity cost and associated gradient when `zero_infinity=True`. So first to make infinity value of cost available, I omit the truncation process done to the logits. And then I do zero operation after the calculation of cost and grad for each batch of the input.

I also add the corresponding test for this two cases. (PS. The test of `inf_test` seems only to pass when the truncation processes are omited.)